### PR TITLE
Chore: Update toolchain to stable in cargo_test.yml

### DIFF
--- a/.github/workflows/cargo_test.yml
+++ b/.github/workflows/cargo_test.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: stable
         override: true
 
     - name: Install rustfmt


### PR DESCRIPTION
Updates the toolchain from `nightly` to `stable` in `cargo_test.yml` such that the CI builds use the `stable` Rust toolchain.
Closes https://github.com/FuelLabs/fuel-merkle/issues/4.