### PR TITLE
Bump bytes from ~1.0 to ~1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = "~1.1.0"
+bytes = "~1.1"
 digest = "~0.9.0"
 fuel-storage = { git = "ssh://git@github.com/FuelLabs/fuel-storage.git" }
 generic-array = "~0.14.4"


### PR DESCRIPTION
Small change, bumping bytes. 

I wanted to include ethers-rs as dependency and:
```
error: failed to select a version for `bytes`.
    ... required by package `ethers-core v0.6.0 (https://github.com/gakonst/ethers-rs#6cecc482)`
    ... which satisfies git dependency `ethers-core` of package `ethers v0.6.0 (https://github.com/gakonst/ethers-rs#6cecc482)`
    ... which satisfies git dependency `ethers` of package `fuel-relayer v0.1.0 (/home/rakita/workspace/fuel-core/crates/relayer)`
versions that meet the requirements `^1.1.0` are: 1.1.0

all possible versions conflict with previously selected packages.

  previously selected package `bytes v1.0.1`
    ... which satisfies dependency `bytes = "~1.0.1"` of package `fuel-merkle v0.1.0 (ssh://git@github.com/FuelLabs/fuel-merkle.git#ff5e7335)`
    ... which satisfies git dependency `fuel-merkle` of package `fuel-vm v0.1.0 (ssh://git@github.com/FuelLabs/fuel-vm.git#1ad56e95)`
    ... which satisfies git dependency `fuel-vm` of package `fuel-client v0.1.0 (/home/rakita/workspace/fuel-core/fuel-client)`

failed to select a version for `bytes` which could resolve this conflict
```

It really is strange and i didnt expect to break, but it seems this is how it works
https://www.reddit.com/r/rust/comments/dje66k/comment/f46k327/?utm_source=share&utm_medium=web2x&context=3
