### PR TITLE
Fix overly restrictive semver requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-merkle"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2018"
 homepage = "https://fuel.network/"


### PR DESCRIPTION
Fuel-merkle was specifying its dependencies in an overly restrictive way that conflicts with dependencies in other projects.