### PR TITLE
Refactor: Binary node interface and encapsulation

### DIFF
--- a/src/binary.rs
+++ b/src/binary.rs
@@ -2,7 +2,7 @@ mod hash;
 mod merkle_tree;
 mod node;
 
-pub(crate) use hash::{empty_sum, leaf_sum, node_sum, Data};
+pub(crate) use hash::{empty_sum, leaf_sum, node_sum};
 pub use merkle_tree::MerkleTree;
 pub use merkle_tree::MerkleTreeError;
 pub(crate) use node::Node;

--- a/src/binary/hash.rs
+++ b/src/binary/hash.rs
@@ -1,27 +1,25 @@
 use digest::Digest;
+
+use crate::common::{Bytes32, LEAF, NODE};
 use lazy_static::lazy_static;
 use sha2::Sha256;
 use std::convert::TryInto;
 
-pub(crate) type Hash = Sha256;
-pub(crate) type Data = [u8; 32];
-
-const NODE: u8 = 0x01;
-const LEAF: u8 = 0x00;
+type Hash = Sha256;
 
 lazy_static! {
-    static ref EMPTY_SUM: Data = Hash::new().finalize().try_into().unwrap();
+    static ref EMPTY_SUM: Bytes32 = Hash::new().finalize().try_into().unwrap();
 }
 
 // Merkle Tree hash of an empty list
 // MTH({}) = Hash()
-pub fn empty_sum() -> &'static Data {
+pub fn empty_sum() -> &'static Bytes32 {
     &*EMPTY_SUM
 }
 
 // Merkle tree hash of an n-element list D[n]
 // MTH(D[n]) = Hash(0x01 || MTH(D[0:k]) || MTH(D[k:n])
-pub fn node_sum(lhs_data: &[u8], rhs_data: &[u8]) -> Data {
+pub fn node_sum(lhs_data: &[u8], rhs_data: &[u8]) -> Bytes32 {
     let mut hash = Hash::new();
     hash.update(&[NODE]);
     hash.update(&lhs_data);
@@ -31,7 +29,7 @@ pub fn node_sum(lhs_data: &[u8], rhs_data: &[u8]) -> Data {
 
 // Merkle tree hash of a list with one entry
 // MTH({d(0)}) = Hash(0x00 || d(0))
-pub fn leaf_sum(data: &[u8]) -> Data {
+pub fn leaf_sum(data: &[u8]) -> Bytes32 {
     let mut hash = Hash::new();
     hash.update(&[LEAF]);
     hash.update(&data);

--- a/src/binary/node.rs
+++ b/src/binary/node.rs
@@ -1,22 +1,22 @@
+use crate::binary::{leaf_sum, node_sum};
 use fuel_storage::Storage;
 use std::fmt::Debug;
 
-use crate::common::Position;
+use crate::common::{Bytes32, Position};
 
 #[derive(Clone, PartialEq, Debug)]
-pub struct Node<Key> {
+pub struct Node {
     position: Position,
-    key: Key,
-    parent_key: Option<Key>,
-    left_key: Option<Key>,
-    right_key: Option<Key>,
+    key: Bytes32,
+    parent_key: Option<Bytes32>,
+    left_key: Option<Bytes32>,
+    right_key: Option<Bytes32>,
 }
 
-impl<Key> Node<Key>
-where
-    Key: Clone,
-{
-    pub fn new(position: Position, key: Key) -> Self {
+impl Node {
+    pub fn create_leaf(index: u64, data: &[u8]) -> Self {
+        let position = Position::from_leaf_index(index);
+        let key = leaf_sum(data);
         Self {
             position,
             key,
@@ -26,60 +26,66 @@ where
         }
     }
 
+    pub fn create_node(left_child: &mut Self, right_child: &mut Self) -> Self {
+        let position = left_child.position().parent();
+        let key = node_sum(&left_child.key(), &right_child.key());
+        let node = Self {
+            position,
+            key,
+            parent_key: None,
+            left_key: Some(left_child.key()),
+            right_key: Some(right_child.key()),
+        };
+        left_child.set_parent_key(Some(node.key()));
+        right_child.set_parent_key(Some(node.key()));
+        node
+    }
+
     pub fn position(&self) -> Position {
         self.position
     }
 
-    pub fn key(&self) -> Key {
-        self.key.clone()
+    pub fn key(&self) -> Bytes32 {
+        self.key
     }
 
-    pub fn parent_key(&self) -> Option<Key> {
+    pub fn parent_key(&self) -> Option<Bytes32> {
         self.parent_key.clone()
     }
 
-    pub fn left_key(&self) -> Option<Key> {
+    pub fn left_key(&self) -> Option<Bytes32> {
         self.left_key.clone()
     }
 
-    pub fn right_key(&self) -> Option<Key> {
+    pub fn right_key(&self) -> Option<Bytes32> {
         self.right_key.clone()
-    }
-
-    pub fn set_parent_key(&mut self, key: Option<Key>) {
-        self.parent_key = key;
-    }
-
-    pub fn set_left_key(&mut self, key: Option<Key>) {
-        self.left_key = key;
-    }
-
-    pub fn set_right_key(&mut self, key: Option<Key>) {
-        self.right_key = key;
     }
 
     pub fn proof_iter<'storage, StorageError: std::error::Error>(
         &mut self,
-        storage: &'storage dyn Storage<Key, Self, Error = StorageError>,
-    ) -> ProofIter<'storage, Key, StorageError> {
+        storage: &'storage dyn Storage<Bytes32, Self, Error = StorageError>,
+    ) -> ProofIter<'storage, StorageError> {
         ProofIter::new(storage, self)
+    }
+
+    fn set_parent_key(&mut self, key: Option<Bytes32>) {
+        self.parent_key = key;
     }
 }
 
-pub struct ProofIter<'storage, Key, StorageError> {
-    storage: &'storage dyn Storage<Key, Node<Key>, Error = StorageError>,
-    prev: Option<Node<Key>>,
-    curr: Option<Node<Key>>,
+pub struct ProofIter<'storage, StorageError> {
+    storage: &'storage dyn Storage<Bytes32, Node, Error = StorageError>,
+    prev: Option<Node>,
+    curr: Option<Node>,
 }
 
-impl<'storage, Key, StorageError> ProofIter<'storage, Key, StorageError>
+impl<'storage, StorageError> ProofIter<'storage, StorageError>
 where
-    Key: Clone,
     StorageError: std::error::Error,
 {
     pub fn new(
-        storage: &'storage dyn Storage<Key, Node<Key>, Error = StorageError>,
-        node: &Node<Key>,
+        storage: &'storage dyn Storage<Bytes32, Node, Error = StorageError>,
+        node: &Node,
     ) -> Self {
         let parent_key = node.parent_key();
         match parent_key {
@@ -100,12 +106,11 @@ where
     }
 }
 
-impl<'storage, Key, StorageError> Iterator for ProofIter<'storage, Key, StorageError>
+impl<'storage, StorageError> Iterator for ProofIter<'storage, StorageError>
 where
-    Key: Clone + std::cmp::PartialEq,
     StorageError: std::error::Error,
 {
-    type Item = Node<Key>;
+    type Item = Node;
 
     fn next(&mut self) -> Option<Self::Item> {
         let previous = self.prev.take();
@@ -141,13 +146,12 @@ where
 #[cfg(test)]
 mod test {
     use crate::binary::Node;
-    use crate::common::{Position, StorageMap};
+    use crate::common::{Bytes32, StorageMap};
+    use fuel_merkle_test_helpers::TEST_DATA;
     use fuel_storage::Storage;
 
     #[test]
     pub fn test_proof_iter() {
-        type N = Node<u32>;
-
         //               07
         //              /  \
         //             /    \
@@ -163,51 +167,22 @@ mod test {
         // 00  02  04  06   08  10    12
         // 00  01  02  03   04  05    06
 
-        let mut leaf_0 = N::new(Position::from_leaf_index(0), 0);
-        let mut leaf_1 = N::new(Position::from_leaf_index(1), 2);
-        let mut leaf_2 = N::new(Position::from_leaf_index(2), 4);
-        let mut leaf_3 = N::new(Position::from_leaf_index(3), 6);
-        let mut leaf_4 = N::new(Position::from_leaf_index(4), 8);
-        let mut leaf_5 = N::new(Position::from_leaf_index(5), 10);
-        let mut leaf_6 = N::new(Position::from_leaf_index(6), 12);
+        let mut leaf_0 = Node::create_leaf(0, TEST_DATA[0]);
+        let mut leaf_1 = Node::create_leaf(1, TEST_DATA[1]);
+        let mut leaf_2 = Node::create_leaf(2, TEST_DATA[2]);
+        let mut leaf_3 = Node::create_leaf(3, TEST_DATA[3]);
+        let mut leaf_4 = Node::create_leaf(4, TEST_DATA[4]);
+        let mut leaf_5 = Node::create_leaf(5, TEST_DATA[5]);
+        let mut leaf_6 = Node::create_leaf(6, TEST_DATA[6]);
 
-        let mut node_1 = N::new(Position::from_in_order_index(1), 1);
-        leaf_0.set_parent_key(Some(node_1.key()));
-        leaf_1.set_parent_key(Some(node_1.key()));
-        node_1.set_left_key(Some(leaf_0.key()));
-        node_1.set_right_key(Some(leaf_1.key()));
+        let mut node_1 = Node::create_node(&mut leaf_0, &mut leaf_1);
+        let mut node_5 = Node::create_node(&mut leaf_2, &mut leaf_3);
+        let mut node_9 = Node::create_node(&mut leaf_4, &mut leaf_5);
+        let mut node_3 = Node::create_node(&mut node_1, &mut node_5);
+        let mut node_11 = Node::create_node(&mut node_9, &mut leaf_6);
+        let node_7 = Node::create_node(&mut node_3, &mut node_11);
 
-        let mut node_5 = N::new(Position::from_in_order_index(5), 5);
-        leaf_2.set_parent_key(Some(node_5.key()));
-        leaf_3.set_parent_key(Some(node_5.key()));
-        node_5.set_left_key(Some(leaf_2.key()));
-        node_5.set_right_key(Some(leaf_3.key()));
-
-        let mut node_9 = N::new(Position::from_in_order_index(9), 9);
-        leaf_4.set_parent_key(Some(node_9.key()));
-        leaf_5.set_parent_key(Some(node_9.key()));
-        node_9.set_left_key(Some(leaf_4.key()));
-        node_9.set_right_key(Some(leaf_5.key()));
-
-        let mut node_3 = N::new(Position::from_in_order_index(3), 3);
-        node_1.set_parent_key(Some(node_3.key()));
-        node_5.set_parent_key(Some(node_3.key()));
-        node_3.set_left_key(Some(node_1.key()));
-        node_3.set_right_key(Some(node_5.key()));
-
-        let mut node_11 = N::new(Position::from_in_order_index(11), 11);
-        node_9.set_parent_key(Some(node_11.key()));
-        leaf_6.set_parent_key(Some(node_11.key()));
-        node_11.set_left_key(Some(node_9.key()));
-        node_11.set_right_key(Some(leaf_6.key()));
-
-        let mut node_7 = N::new(Position::from_in_order_index(7), 7);
-        node_3.set_parent_key(Some(node_7.key()));
-        node_11.set_parent_key(Some(node_7.key()));
-        node_7.set_left_key(Some(node_3.key()));
-        node_7.set_right_key(Some(node_11.key()));
-
-        let mut storage_map = StorageMap::<u32, N>::new();
+        let mut storage_map = StorageMap::<Bytes32, Node>::new();
         let _ = storage_map.insert(&leaf_1.key(), &leaf_1);
         let _ = storage_map.insert(&leaf_2.key(), &leaf_2);
         let _ = storage_map.insert(&leaf_0.key(), &leaf_0);
@@ -223,31 +198,31 @@ mod test {
         let _ = storage_map.insert(&node_7.key(), &node_7);
 
         let iter = leaf_0.proof_iter(&mut storage_map);
-        let col: Vec<N> = iter.collect();
+        let col: Vec<Node> = iter.collect();
         assert_eq!(col, vec!(leaf_1.clone(), node_5.clone(), node_11.clone()));
 
         let iter = leaf_1.proof_iter(&mut storage_map);
-        let col: Vec<N> = iter.collect();
+        let col: Vec<Node> = iter.collect();
         assert_eq!(col, vec!(leaf_0.clone(), node_5.clone(), node_11.clone()));
 
         let iter = leaf_2.proof_iter(&mut storage_map);
-        let col: Vec<N> = iter.collect();
+        let col: Vec<Node> = iter.collect();
         assert_eq!(col, vec!(leaf_3.clone(), node_1.clone(), node_11.clone()));
 
         let iter = leaf_3.proof_iter(&mut storage_map);
-        let col: Vec<N> = iter.collect();
+        let col: Vec<Node> = iter.collect();
         assert_eq!(col, vec!(leaf_2.clone(), node_1.clone(), node_11.clone()));
 
         let iter = leaf_4.proof_iter(&mut storage_map);
-        let col: Vec<N> = iter.collect();
+        let col: Vec<Node> = iter.collect();
         assert_eq!(col, vec!(leaf_5.clone(), leaf_6.clone(), node_3.clone()));
 
         let iter = leaf_5.proof_iter(&mut storage_map);
-        let col: Vec<N> = iter.collect();
+        let col: Vec<Node> = iter.collect();
         assert_eq!(col, vec!(leaf_4.clone(), leaf_6.clone(), node_3.clone()));
 
         let iter = leaf_6.proof_iter(&mut storage_map);
-        let col: Vec<N> = iter.collect();
+        let col: Vec<Node> = iter.collect();
         assert_eq!(col, vec!(node_9.clone(), node_3.clone()));
     }
 }


### PR DESCRIPTION
Related issues:
- https://github.com/FuelLabs/fuel-merkle/issues/31
- https://github.com/FuelLabs/fuel-merkle/issues/28

This PR refactors the binary node interface to add the following properties:
- Binary module reuses types from the common module instead of recreating them (e.g., using `use common::Bytes32` instead of `type Data = [u8; 32]`)
- Binary node encapsulates internal logic for calculating hash sums, setting child/parent keys, etc.
- Binary Merkle tree is now agnostic of binary node internal logic
- Simplifies code overall

This PR puts the code into a better position for future feature development by improving encapsulation and decreasing coupling between the binary node and tree structures. In a future PR, BMT nodes will be refactored to use positional  paths and traversal. BMT storage will be keyed with in-order indices, allowing clients to interface with the storage more simply, i.e. using leaf indices, and reducing the in-memory footprint of the BMT.