### PR TITLE
Feat: BMT prove uses position path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-merkle"
-version = "0.2.0"
+version = "0.1.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2018"
 homepage = "https://fuel.network/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-merkle"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2018"
 homepage = "https://fuel.network/"

--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -51,10 +51,13 @@ where
         let root_node = self.root_node()?.unwrap();
         let root_position = root_node.position();
         let leaf_position = Position::from_leaf_index(proof_index);
-        let leaf_node=  self.storage.get(&leaf_position.in_order_index())?.unwrap();
+        let leaf_node = self.storage.get(&leaf_position.in_order_index())?.unwrap();
         proof_set.push(*leaf_node.hash());
 
-        let (_, mut side_positions): (Vec<_>, Vec<_>) = root_position.path(&leaf_position, self.leaves_count).iter().unzip();
+        let (_, mut side_positions): (Vec<_>, Vec<_>) = root_position
+            .path(&leaf_position, self.leaves_count)
+            .iter()
+            .unzip();
         side_positions.reverse(); // Reorder side positions from leaf to root.
         side_positions.pop(); // The last side position is the root; remove it.
 

--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -134,9 +134,6 @@ where
     ) -> Result<Box<Subtree<Node>>, Box<dyn std::error::Error>> {
         let joined_node = Node::create_node(lhs.node_mut(), rhs.node_mut());
         self.storage.insert(&joined_node.key(), &joined_node)?;
-        self.storage.insert(&lhs.node().key(), lhs.node())?;
-        self.storage.insert(&rhs.node().key(), rhs.node())?;
-
         let joined_head = Subtree::new(joined_node, lhs.take_next());
         Ok(Box::new(joined_head))
     }

--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -1,7 +1,7 @@
 use fuel_storage::Storage;
 
 use crate::binary::{empty_sum, Node};
-use crate::common::{Bytes32, Subtree};
+use crate::common::{Bytes32, Position, Subtree};
 
 #[derive(Debug, thiserror::Error)]
 pub enum MerkleTreeError {
@@ -12,9 +12,8 @@ pub enum MerkleTreeError {
 type ProofSet = Vec<Bytes32>;
 
 pub struct MerkleTree<'storage, StorageError> {
-    storage: &'storage mut dyn Storage<Bytes32, Node, Error = StorageError>,
+    storage: &'storage mut dyn Storage<u64, Node, Error = StorageError>,
     head: Option<Box<Subtree<Node>>>,
-    leaves: Vec<Bytes32>,
     leaves_count: u64,
 }
 
@@ -22,32 +21,23 @@ impl<'storage, StorageError> MerkleTree<'storage, StorageError>
 where
     StorageError: std::error::Error + 'static,
 {
-    pub fn new(storage: &'storage mut dyn Storage<Bytes32, Node, Error = StorageError>) -> Self {
+    pub fn new(storage: &'storage mut dyn Storage<u64, Node, Error = StorageError>) -> Self {
         Self {
             storage,
             head: None,
-            leaves: Vec::<Bytes32>::default(),
             leaves_count: 0,
         }
     }
 
     pub fn root(&mut self) -> Result<Bytes32, Box<dyn std::error::Error>> {
-        let root = match self.head {
+        let root_node = self.root_node()?;
+        let root = match root_node {
             None => *empty_sum(),
-            Some(ref initial) => {
-                let mut current = initial.clone();
-                while current.next().is_some() {
-                    let mut head = current;
-                    let mut head_next = head.take_next().unwrap();
-                    current = self.join_subtrees(&mut head_next, &mut head)?
-                }
-                current.node().key()
-            }
+            Some(ref node) => *node.hash(),
         };
 
         Ok(root)
     }
-
     pub fn prove(
         &mut self,
         proof_index: u64,
@@ -56,25 +46,30 @@ where
             return Err(Box::new(MerkleTreeError::InvalidProofIndex(proof_index)));
         }
 
-        let root = self.root()?;
         let mut proof_set = ProofSet::new();
 
-        let key = self.leaves[proof_index as usize];
-        proof_set.push(key);
+        let root_node = self.root_node()?.unwrap();
+        let root_position = root_node.position();
+        let leaf_position = Position::from_leaf_index(proof_index);
+        let leaf_node=  self.storage.get(&leaf_position.in_order_index())?.unwrap();
+        proof_set.push(*leaf_node.hash());
 
-        let mut node = self.storage.get(&key)?.unwrap();
-        let iter = node.to_mut().proof_iter(self.storage);
-        for n in iter {
-            proof_set.push(n.key());
+        let (_, mut side_positions): (Vec<_>, Vec<_>) = root_position.path(&leaf_position, self.leaves_count).iter().unzip();
+        side_positions.reverse(); // Reorder side positions from leaf to root.
+        side_positions.pop(); // The last side position is the root; remove it.
+
+        for side_position in side_positions {
+            let key = side_position.in_order_index();
+            let node = self.storage.get(&key)?.unwrap();
+            proof_set.push(*node.hash());
         }
 
-        Ok((root, proof_set))
+        Ok((self.root()?, proof_set))
     }
 
     pub fn push(&mut self, data: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
         let node = Node::create_leaf(self.leaves_count, data);
         self.storage.insert(&node.key(), &node)?;
-        self.leaves.push(node.key());
 
         let next = self.head.take();
         let head = Box::new(Subtree::<Node>::new(node, next));
@@ -89,6 +84,23 @@ where
     //
     // PRIVATE
     //
+
+    fn root_node(&mut self) -> Result<Option<Node>, Box<dyn std::error::Error>> {
+        let root_node = match self.head {
+            None => None,
+            Some(ref initial) => {
+                let mut current = initial.clone();
+                while current.next().is_some() {
+                    let mut head = current;
+                    let mut head_next = head.take_next().unwrap();
+                    current = self.join_subtrees(&mut head_next, &mut head)?
+                }
+                Some(current.node().clone())
+            }
+        };
+
+        Ok(root_node)
+    }
 
     fn join_all_subtrees(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         loop {
@@ -131,14 +143,14 @@ where
 mod test {
     use super::{MerkleTree, Storage};
     use crate::binary::{empty_sum, leaf_sum, node_sum, Node};
-    use crate::common::{Bytes32, StorageError, StorageMap};
+    use crate::common::{StorageError, StorageMap};
     use fuel_merkle_test_helpers::TEST_DATA;
 
     type MT<'a> = MerkleTree<'a, StorageError>;
 
     #[test]
     fn test_push_builds_internal_tree_structure() {
-        let mut storage_map = StorageMap::<Bytes32, Node>::new();
+        let mut storage_map = StorageMap::<u64, Node>::new();
         let mut tree = MT::new(&mut storage_map);
 
         let data = &TEST_DATA[0..7]; // 7 leaves
@@ -168,71 +180,39 @@ mod test {
         let leaf_4 = leaf_sum(&data[4]);
         let leaf_5 = leaf_sum(&data[5]);
         let leaf_6 = leaf_sum(&data[6]);
-
         let node_1 = node_sum(&leaf_0, &leaf_1);
         let node_5 = node_sum(&leaf_2, &leaf_3);
         let node_3 = node_sum(&node_1, &node_5);
         let node_9 = node_sum(&leaf_4, &leaf_5);
 
-        let s_leaf_0 = storage_map.get(&leaf_0).unwrap().unwrap();
-        assert_eq!(s_leaf_0.left_key(), None);
-        assert_eq!(s_leaf_0.right_key(), None);
-        assert_eq!(s_leaf_0.parent_key(), Some(node_1.clone()));
+        let s_leaf_0 = storage_map.get(&0).unwrap().unwrap();
+        let s_leaf_1 = storage_map.get(&2).unwrap().unwrap();
+        let s_leaf_2 = storage_map.get(&4).unwrap().unwrap();
+        let s_leaf_3 = storage_map.get(&6).unwrap().unwrap();
+        let s_leaf_4 = storage_map.get(&8).unwrap().unwrap();
+        let s_leaf_5 = storage_map.get(&10).unwrap().unwrap();
+        let s_leaf_6 = storage_map.get(&12).unwrap().unwrap();
+        let s_node_1 = storage_map.get(&1).unwrap().unwrap();
+        let s_node_5 = storage_map.get(&5).unwrap().unwrap();
+        let s_node_9 = storage_map.get(&9).unwrap().unwrap();
+        let s_node_3 = storage_map.get(&3).unwrap().unwrap();
 
-        let s_leaf_1 = storage_map.get(&leaf_1).unwrap().unwrap();
-        assert_eq!(s_leaf_1.left_key(), None);
-        assert_eq!(s_leaf_1.right_key(), None);
-        assert_eq!(s_leaf_1.parent_key(), Some(node_1.clone()));
-
-        let s_leaf_2 = storage_map.get(&leaf_2).unwrap().unwrap();
-        assert_eq!(s_leaf_2.left_key(), None);
-        assert_eq!(s_leaf_2.right_key(), None);
-        assert_eq!(s_leaf_2.parent_key(), Some(node_5.clone()));
-
-        let s_leaf_3 = storage_map.get(&leaf_3).unwrap().unwrap();
-        assert_eq!(s_leaf_3.left_key(), None);
-        assert_eq!(s_leaf_3.right_key(), None);
-        assert_eq!(s_leaf_3.parent_key(), Some(node_5.clone()));
-
-        let s_leaf_4 = storage_map.get(&leaf_4).unwrap().unwrap();
-        assert_eq!(s_leaf_4.left_key(), None);
-        assert_eq!(s_leaf_4.right_key(), None);
-        assert_eq!(s_leaf_4.parent_key(), Some(node_9.clone()));
-
-        let s_leaf_5 = storage_map.get(&leaf_5).unwrap().unwrap();
-        assert_eq!(s_leaf_5.left_key(), None);
-        assert_eq!(s_leaf_5.right_key(), None);
-        assert_eq!(s_leaf_5.parent_key(), Some(node_9.clone()));
-
-        let s_leaf_6 = storage_map.get(&leaf_6).unwrap().unwrap();
-        assert_eq!(s_leaf_6.left_key(), None);
-        assert_eq!(s_leaf_6.right_key(), None);
-        assert_eq!(s_leaf_6.parent_key(), None);
-
-        let s_node_1 = storage_map.get(&node_1).unwrap().unwrap();
-        assert_eq!(s_node_1.left_key(), Some(leaf_0.clone()));
-        assert_eq!(s_node_1.right_key(), Some(leaf_1.clone()));
-        assert_eq!(s_node_1.parent_key(), Some(node_3.clone()));
-
-        let s_node_5 = storage_map.get(&node_5).unwrap().unwrap();
-        assert_eq!(s_node_5.left_key(), Some(leaf_2.clone()));
-        assert_eq!(s_node_5.right_key(), Some(leaf_3.clone()));
-        assert_eq!(s_node_5.parent_key(), Some(node_3.clone()));
-
-        let s_node_9 = storage_map.get(&node_9).unwrap().unwrap();
-        assert_eq!(s_node_9.left_key(), Some(leaf_4.clone()));
-        assert_eq!(s_node_9.right_key(), Some(leaf_5.clone()));
-        assert_eq!(s_node_9.parent_key(), None);
-
-        let s_node_3 = storage_map.get(&node_3).unwrap().unwrap();
-        assert_eq!(s_node_3.left_key(), Some(node_1.clone()));
-        assert_eq!(s_node_3.right_key(), Some(node_5.clone()));
-        assert_eq!(s_node_3.parent_key(), None);
+        assert_eq!(s_leaf_0.hash(), &leaf_0);
+        assert_eq!(s_leaf_1.hash(), &leaf_1);
+        assert_eq!(s_leaf_2.hash(), &leaf_2);
+        assert_eq!(s_leaf_3.hash(), &leaf_3);
+        assert_eq!(s_leaf_4.hash(), &leaf_4);
+        assert_eq!(s_leaf_5.hash(), &leaf_5);
+        assert_eq!(s_leaf_6.hash(), &leaf_6);
+        assert_eq!(s_node_1.hash(), &node_1);
+        assert_eq!(s_node_5.hash(), &node_5);
+        assert_eq!(s_node_9.hash(), &node_9);
+        assert_eq!(s_node_3.hash(), &node_3);
     }
 
     #[test]
     fn root_returns_the_empty_root_for_0_leaves() {
-        let mut storage_map = StorageMap::<Bytes32, Node>::new();
+        let mut storage_map = StorageMap::<u64, Node>::new();
         let mut tree = MT::new(&mut storage_map);
 
         let root = tree.root().unwrap();
@@ -241,7 +221,7 @@ mod test {
 
     #[test]
     fn root_returns_the_merkle_root_for_1_leaf() {
-        let mut storage_map = StorageMap::<Bytes32, Node>::new();
+        let mut storage_map = StorageMap::<u64, Node>::new();
         let mut tree = MT::new(&mut storage_map);
 
         let data = &TEST_DATA[0..1]; // 1 leaf
@@ -257,7 +237,7 @@ mod test {
 
     #[test]
     fn root_returns_the_merkle_root_for_7_leaves() {
-        let mut storage_map = StorageMap::<Bytes32, Node>::new();
+        let mut storage_map = StorageMap::<u64, Node>::new();
         let mut tree = MT::new(&mut storage_map);
 
         let data = &TEST_DATA[0..7]; // 7 leaves
@@ -301,7 +281,7 @@ mod test {
 
     #[test]
     fn prove_returns_invalid_proof_index_error_for_0_leaves() {
-        let mut storage_map = StorageMap::<Bytes32, Node>::new();
+        let mut storage_map = StorageMap::<u64, Node>::new();
         let mut tree = MT::new(&mut storage_map);
 
         let proof = tree.prove(0);
@@ -310,7 +290,7 @@ mod test {
 
     #[test]
     fn prove_returns_invalid_proof_index_error_when_index_is_greater_than_number_of_leaves() {
-        let mut storage_map = StorageMap::<Bytes32, Node>::new();
+        let mut storage_map = StorageMap::<u64, Node>::new();
         let mut tree = MT::new(&mut storage_map);
 
         let data = &TEST_DATA[0..5]; // 5 leaves
@@ -324,7 +304,7 @@ mod test {
 
     #[test]
     fn prove_returns_the_merkle_root_and_proof_set_for_1_leaf() {
-        let mut storage_map = StorageMap::<Bytes32, Node>::new();
+        let mut storage_map = StorageMap::<u64, Node>::new();
         let mut tree = MT::new(&mut storage_map);
 
         let data = &TEST_DATA[0..1]; // 1 leaf
@@ -346,7 +326,7 @@ mod test {
 
     #[test]
     fn prove_returns_the_merkle_root_and_proof_set_for_4_leaves() {
-        let mut storage_map = StorageMap::<Bytes32, Node>::new();
+        let mut storage_map = StorageMap::<u64, Node>::new();
         let mut tree = MT::new(&mut storage_map);
 
         let data = &TEST_DATA[0..4]; // 4 leaves
@@ -415,7 +395,7 @@ mod test {
 
     #[test]
     fn prove_returns_the_merkle_root_and_proof_set_for_5_leaves() {
-        let mut storage_map = StorageMap::<Bytes32, Node>::new();
+        let mut storage_map = StorageMap::<u64, Node>::new();
         let mut tree = MT::new(&mut storage_map);
 
         let data = &TEST_DATA[0..5]; // 5 leaves
@@ -502,7 +482,7 @@ mod test {
 
     #[test]
     fn prove_returns_the_merkle_root_and_proof_set_for_7_leaves() {
-        let mut storage_map = StorageMap::<Bytes32, Node>::new();
+        let mut storage_map = StorageMap::<u64, Node>::new();
         let mut tree = MT::new(&mut storage_map);
 
         let data = &TEST_DATA[0..7]; // 7 leaves

--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -132,7 +132,7 @@ where
         lhs: &mut Subtree<Node>,
         rhs: &mut Subtree<Node>,
     ) -> Result<Box<Subtree<Node>>, Box<dyn std::error::Error>> {
-        let joined_node = Node::create_node(lhs.node_mut(), rhs.node_mut());
+        let joined_node = Node::create_node(lhs.node(), rhs.node());
         self.storage.insert(&joined_node.key(), &joined_node)?;
         let joined_head = Subtree::new(joined_node, lhs.take_next());
         Ok(Box::new(joined_head))

--- a/src/binary/node.rs
+++ b/src/binary/node.rs
@@ -1,5 +1,4 @@
 use crate::binary::{leaf_sum, node_sum};
-use fuel_storage::Storage;
 use std::fmt::Debug;
 
 use crate::common::{Bytes32, Position};
@@ -7,222 +6,45 @@ use crate::common::{Bytes32, Position};
 #[derive(Clone, PartialEq, Debug)]
 pub struct Node {
     position: Position,
-    key: Bytes32,
-    parent_key: Option<Bytes32>,
-    left_key: Option<Bytes32>,
-    right_key: Option<Bytes32>,
+    hash: Bytes32,
 }
 
 impl Node {
     pub fn create_leaf(index: u64, data: &[u8]) -> Self {
         let position = Position::from_leaf_index(index);
-        let key = leaf_sum(data);
+        let hash = leaf_sum(data);
         Self {
             position,
-            key,
-            parent_key: None,
-            left_key: None,
-            right_key: None,
+            hash
         }
     }
 
     pub fn create_node(left_child: &mut Self, right_child: &mut Self) -> Self {
         let position = left_child.position().parent();
-        let key = node_sum(&left_child.key(), &right_child.key());
-        let node = Self {
+        let hash = node_sum(left_child.hash(), right_child.hash());
+        Self {
             position,
-            key,
-            parent_key: None,
-            left_key: Some(left_child.key()),
-            right_key: Some(right_child.key()),
-        };
-        left_child.set_parent_key(Some(node.key()));
-        right_child.set_parent_key(Some(node.key()));
-        node
+            hash
+        }
     }
 
     pub fn position(&self) -> Position {
         self.position
     }
 
-    pub fn key(&self) -> Bytes32 {
-        self.key
+    pub fn key(&self) -> u64 {
+        self.position().in_order_index()
     }
 
-    pub fn parent_key(&self) -> Option<Bytes32> {
-        self.parent_key.clone()
+    pub fn left_key(&self) -> u64 {
+        self.position().left_child().in_order_index()
     }
 
-    pub fn left_key(&self) -> Option<Bytes32> {
-        self.left_key.clone()
+    pub fn right_key(&self) -> u64 {
+        self.position().right_child().in_order_index()
     }
 
-    pub fn right_key(&self) -> Option<Bytes32> {
-        self.right_key.clone()
-    }
-
-    pub fn proof_iter<'storage, StorageError: std::error::Error>(
-        &mut self,
-        storage: &'storage dyn Storage<Bytes32, Self, Error = StorageError>,
-    ) -> ProofIter<'storage, StorageError> {
-        ProofIter::new(storage, self)
-    }
-
-    fn set_parent_key(&mut self, key: Option<Bytes32>) {
-        self.parent_key = key;
-    }
-}
-
-pub struct ProofIter<'storage, StorageError> {
-    storage: &'storage dyn Storage<Bytes32, Node, Error = StorageError>,
-    prev: Option<Node>,
-    curr: Option<Node>,
-}
-
-impl<'storage, StorageError> ProofIter<'storage, StorageError>
-where
-    StorageError: std::error::Error,
-{
-    pub fn new(
-        storage: &'storage dyn Storage<Bytes32, Node, Error = StorageError>,
-        node: &Node,
-    ) -> Self {
-        let parent_key = node.parent_key();
-        match parent_key {
-            None => Self {
-                storage,
-                prev: Some(node.clone()),
-                curr: None,
-            },
-            Some(key) => {
-                let curr = storage.get(&key).unwrap().unwrap();
-                Self {
-                    storage,
-                    prev: Some(node.clone()),
-                    curr: Some(curr.into_owned()),
-                }
-            }
-        }
-    }
-}
-
-impl<'storage, StorageError> Iterator for ProofIter<'storage, StorageError>
-where
-    StorageError: std::error::Error,
-{
-    type Item = Node;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let previous = self.prev.take();
-        let mut current = self.curr.take();
-
-        let node = current.as_ref().map(|curr| {
-            let prev = previous.unwrap();
-            if curr.left_key().unwrap() == prev.key() {
-                self.storage
-                    .get(&curr.right_key().unwrap())
-                    .unwrap()
-                    .unwrap()
-                    .into_owned()
-            } else {
-                self.storage
-                    .get(&curr.left_key().unwrap())
-                    .unwrap()
-                    .unwrap()
-                    .into_owned()
-            }
-        });
-
-        self.curr = current
-            .as_ref()?
-            .parent_key()
-            .map(|key| self.storage.get(&key).unwrap().unwrap().into_owned());
-        self.prev = current.take();
-
-        node
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use crate::binary::Node;
-    use crate::common::{Bytes32, StorageMap};
-    use fuel_merkle_test_helpers::TEST_DATA;
-    use fuel_storage::Storage;
-
-    #[test]
-    pub fn test_proof_iter() {
-        //               07
-        //              /  \
-        //             /    \
-        //            /      \
-        //           /        \
-        //          /          \
-        //         /            \
-        //       03              11
-        //      /  \            /  \
-        //     /    \          /    \
-        //   01      05       09     \
-        //  /  \    /  \     /  \     \
-        // 00  02  04  06   08  10    12
-        // 00  01  02  03   04  05    06
-
-        let mut leaf_0 = Node::create_leaf(0, TEST_DATA[0]);
-        let mut leaf_1 = Node::create_leaf(1, TEST_DATA[1]);
-        let mut leaf_2 = Node::create_leaf(2, TEST_DATA[2]);
-        let mut leaf_3 = Node::create_leaf(3, TEST_DATA[3]);
-        let mut leaf_4 = Node::create_leaf(4, TEST_DATA[4]);
-        let mut leaf_5 = Node::create_leaf(5, TEST_DATA[5]);
-        let mut leaf_6 = Node::create_leaf(6, TEST_DATA[6]);
-
-        let mut node_1 = Node::create_node(&mut leaf_0, &mut leaf_1);
-        let mut node_5 = Node::create_node(&mut leaf_2, &mut leaf_3);
-        let mut node_9 = Node::create_node(&mut leaf_4, &mut leaf_5);
-        let mut node_3 = Node::create_node(&mut node_1, &mut node_5);
-        let mut node_11 = Node::create_node(&mut node_9, &mut leaf_6);
-        let node_7 = Node::create_node(&mut node_3, &mut node_11);
-
-        let mut storage_map = StorageMap::<Bytes32, Node>::new();
-        let _ = storage_map.insert(&leaf_1.key(), &leaf_1);
-        let _ = storage_map.insert(&leaf_2.key(), &leaf_2);
-        let _ = storage_map.insert(&leaf_0.key(), &leaf_0);
-        let _ = storage_map.insert(&leaf_3.key(), &leaf_3);
-        let _ = storage_map.insert(&leaf_4.key(), &leaf_4);
-        let _ = storage_map.insert(&leaf_5.key(), &leaf_5);
-        let _ = storage_map.insert(&leaf_6.key(), &leaf_6);
-        let _ = storage_map.insert(&node_1.key(), &node_1);
-        let _ = storage_map.insert(&node_5.key(), &node_5);
-        let _ = storage_map.insert(&node_9.key(), &node_9);
-        let _ = storage_map.insert(&node_3.key(), &node_3);
-        let _ = storage_map.insert(&node_11.key(), &node_11);
-        let _ = storage_map.insert(&node_7.key(), &node_7);
-
-        let iter = leaf_0.proof_iter(&mut storage_map);
-        let col: Vec<Node> = iter.collect();
-        assert_eq!(col, vec!(leaf_1.clone(), node_5.clone(), node_11.clone()));
-
-        let iter = leaf_1.proof_iter(&mut storage_map);
-        let col: Vec<Node> = iter.collect();
-        assert_eq!(col, vec!(leaf_0.clone(), node_5.clone(), node_11.clone()));
-
-        let iter = leaf_2.proof_iter(&mut storage_map);
-        let col: Vec<Node> = iter.collect();
-        assert_eq!(col, vec!(leaf_3.clone(), node_1.clone(), node_11.clone()));
-
-        let iter = leaf_3.proof_iter(&mut storage_map);
-        let col: Vec<Node> = iter.collect();
-        assert_eq!(col, vec!(leaf_2.clone(), node_1.clone(), node_11.clone()));
-
-        let iter = leaf_4.proof_iter(&mut storage_map);
-        let col: Vec<Node> = iter.collect();
-        assert_eq!(col, vec!(leaf_5.clone(), leaf_6.clone(), node_3.clone()));
-
-        let iter = leaf_5.proof_iter(&mut storage_map);
-        let col: Vec<Node> = iter.collect();
-        assert_eq!(col, vec!(leaf_4.clone(), leaf_6.clone(), node_3.clone()));
-
-        let iter = leaf_6.proof_iter(&mut storage_map);
-        let col: Vec<Node> = iter.collect();
-        assert_eq!(col, vec!(node_9.clone(), node_3.clone()));
+    pub fn hash(&self) -> &Bytes32 {
+        &self.hash
     }
 }

--- a/src/binary/node.rs
+++ b/src/binary/node.rs
@@ -16,7 +16,7 @@ impl Node {
         Self { position, hash }
     }
 
-    pub fn create_node(left_child: &mut Self, right_child: &mut Self) -> Self {
+    pub fn create_node(left_child: &Self, right_child: &Self) -> Self {
         let position = left_child.position().parent();
         let hash = node_sum(left_child.hash(), right_child.hash());
         Self { position, hash }

--- a/src/binary/node.rs
+++ b/src/binary/node.rs
@@ -13,19 +13,13 @@ impl Node {
     pub fn create_leaf(index: u64, data: &[u8]) -> Self {
         let position = Position::from_leaf_index(index);
         let hash = leaf_sum(data);
-        Self {
-            position,
-            hash
-        }
+        Self { position, hash }
     }
 
     pub fn create_node(left_child: &mut Self, right_child: &mut Self) -> Self {
         let position = left_child.position().parent();
         let hash = node_sum(left_child.hash(), right_child.hash());
-        Self {
-            position,
-            hash
-        }
+        Self { position, hash }
     }
 
     pub fn position(&self) -> Position {

--- a/src/binary/node.rs
+++ b/src/binary/node.rs
@@ -30,14 +30,6 @@ impl Node {
         self.position().in_order_index()
     }
 
-    pub fn left_key(&self) -> u64 {
-        self.position().left_child().in_order_index()
-    }
-
-    pub fn right_key(&self) -> u64 {
-        self.position().right_child().in_order_index()
-    }
-
     pub fn hash(&self) -> &Bytes32 {
         &self.hash
     }


### PR DESCRIPTION
Related issues:
- Closes https://github.com/FuelLabs/fuel-merkle/issues/31
- Progresses https://github.com/FuelLabs/fuel-merkle/issues/28

This PR replaces the existing method of Binary Merkle Tree traversal with positional path iteration introduced in a previous PR https://github.com/FuelLabs/fuel-merkle/pull/55. This allows the binary tree storage to use integer (`u64`) keys, rather than hash (`Bytes32`) keys. For dense trees, such as BMTs, integer keys are better suited than hash keys for the underlying storage backing. This is because dense trees operate on their running count of leaves. This count is used when generating storage keys. 

This approach has a number of strong advantages:
- Positional path traversal does not require storage loads, allowing a clean separation between traversal and storage loads. Storage loads can then be performed in a cheaper bulk operation.
- Positional path traversal eliminates node pointers (i.e. `left_child_key`, `right_child_key`) and reduces cache thrashing.
- Inserting positional nodes requires only one storage insert, rather than three, by removing the need to update parent pointers in the already-stored left and right nodes. (See https://github.com/FuelLabs/fuel-merkle/pull/61/files#diff-e809f5638584af006d5dfc8ded1ccc5900cdbeb5b45ba4afc7afbed81dee4ed1L122)
- The tree no longer needs any indirection struct between a leaf index and a leaf key; rather, the storage uses leaf indices directly. This simplifies the tree struct, and significantly reduces its memory footprint. (See https://github.com/FuelLabs/fuel-merkle/pull/61/files#diff-e809f5638584af006d5dfc8ded1ccc5900cdbeb5b45ba4afc7afbed81dee4ed1L17)
- The node structure is greatly simplified and is agnostic of the storage strategy employed by the tree.