### PR TITLE
Feat: Binary merkle tree load from storage

### DIFF
--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -114,7 +114,7 @@ where
             let node = self
                 .storage
                 .get(&key)?
-                .ok_or(Box::new(MerkleTreeError::LoadError(key)))?
+                .ok_or(MerkleTreeError::LoadError(key))?
                 .into_owned();
             let next = self.head.take();
             let head = Box::new(Subtree::<Node>::new(node, next));

--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -276,7 +276,7 @@ mod test {
 
         {
             let mut tree = MT::new(&mut storage_map);
-            let data = &TEST_DATA[0..5 as usize];
+            let data = &TEST_DATA[0..5];
             for datum in data.iter() {
                 let _ = tree.push(datum);
             }

--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -283,7 +283,7 @@ mod test {
         }
 
         {
-            let mut tree = MT::load(&mut storage_map, 10);
+            let tree = MT::load(&mut storage_map, 10);
             assert!(tree.is_err());
         }
     }

--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -1,7 +1,7 @@
 use fuel_storage::Storage;
 
 use crate::binary::{empty_sum, Node};
-use crate::common::{Bytes32, Position, Subtree, p2_under};
+use crate::common::{p2_under, Bytes32, Position, Subtree};
 
 #[derive(Debug, thiserror::Error)]
 pub enum MerkleTreeError {

--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -5,11 +5,11 @@ use crate::common::{Bytes32, Position, Subtree};
 
 #[derive(Debug, thiserror::Error)]
 pub enum MerkleTreeError {
-    #[error("cannot load node with key {0}; the key is not found in storage")]
-    LoadError(u64),
-
     #[error("proof index {0} is not valid")]
     InvalidProofIndex(u64),
+
+    #[error("cannot load node with key {0}; the key is not found in storage")]
+    LoadError(u64),
 }
 
 type ProofSet = Vec<Bytes32>;

--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -1,15 +1,7 @@
 use fuel_storage::Storage;
 
 use crate::binary::{empty_sum, Node};
-use crate::common::{Bytes32, Position, Subtree};
-
-fn p2(x: u64) -> u64 {
-    if x == 0 {
-        return x;
-    }
-
-    1 << (63 - x.leading_zeros())
-}
+use crate::common::{Bytes32, Position, Subtree, p2_under};
 
 #[derive(Debug, thiserror::Error)]
 pub enum MerkleTreeError {
@@ -47,7 +39,7 @@ where
         let mut undistributed_leaves_count = leaves_count;
 
         while undistributed_leaves_count > 0 {
-            let mountain_leaves_count = p2(undistributed_leaves_count);
+            let mountain_leaves_count = p2_under(undistributed_leaves_count);
             undistributed_leaves_count -= mountain_leaves_count;
 
             let mountain_head = {
@@ -192,7 +184,7 @@ where
 mod test {
     use super::{MerkleTree, Storage};
     use crate::binary::{empty_sum, leaf_sum, node_sum, Node};
-    use crate::common::{Position, StorageError, StorageMap};
+    use crate::common::{StorageError, StorageMap};
     use fuel_merkle_test_helpers::TEST_DATA;
 
     type MT<'a> = MerkleTree<'a, StorageError>;

--- a/src/common.rs
+++ b/src/common.rs
@@ -27,6 +27,14 @@ pub type Bytes8 = [u8; 8];
 pub type Bytes16 = [u8; 16];
 pub type Bytes32 = [u8; 32];
 
+pub fn p2_under(x: u64) -> u64 {
+    if x == 0 {
+        return x;
+    }
+
+    1 << (63 - x.leading_zeros())
+}
+
 /// For a leaf:
 /// `00 - 01`: Prefix (1 byte, 0x00),
 /// `01 - 33`: hash(Key) (32 bytes),

--- a/src/common.rs
+++ b/src/common.rs
@@ -27,14 +27,6 @@ pub type Bytes8 = [u8; 8];
 pub type Bytes16 = [u8; 16];
 pub type Bytes32 = [u8; 32];
 
-pub fn p2_under(x: u64) -> u64 {
-    if x == 0 {
-        return x;
-    }
-
-    1 << (63 - x.leading_zeros())
-}
-
 /// For a leaf:
 /// `00 - 01`: Prefix (1 byte, 0x00),
 /// `01 - 33`: hash(Key) (32 bytes),


### PR DESCRIPTION
Related issues:
- Closes #28 

This PR adds the ability to load a Binary Merkle tree from storage, given a storage reference and number of leaves. 

The binary Merkle tree class exposes the static method `load`, and takes the storage reference and number of leaves as arguments. This method returns a result: if the tree can be built from the storage reference, the built tree is returned; otherwise, an error is returned.

Building the tree from storage is done by reading the leaf nodes from the storage, and iteratively calculating the internal nodes. This approach requires that the storage has all the leaf nodes stored for the tree described by the `leaves_count` argument. It does not require that any internal nodes be calculated and stored beforehand. This makes the approach suitable for environments where the state of the storage backing cannot be guaranteed. For example, if a tree has all of its leaves saved in storage, and is only partially built (i.e., not all internal nodes are calculated due to a previous error), we can attempt to rebuild this tree by loading it from its storage. This approach requires `n` storage loads, where `n` is the number of leaves. 