### PR TITLE
Feat: Add height to sparse node

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 mod msb;
 mod node;
 mod path_iterator;
@@ -26,16 +24,3 @@ pub type Bytes4 = [u8; 4];
 pub type Bytes8 = [u8; 8];
 pub type Bytes16 = [u8; 16];
 pub type Bytes32 = [u8; 32];
-
-/// For a leaf:
-/// `00 - 01`: Prefix (1 byte, 0x00),
-/// `01 - 33`: hash(Key) (32 bytes),
-/// `33 - 65`: hash(Data) (32 bytes)
-///
-/// For a node:
-/// `00 - 01`: Prefix (1 byte, 0x01),
-/// `01 - 32`: Left child key (32 bytes),
-/// `33 - 65`: Right child key (32 bytes)
-///
-const BUFFER_SIZE: usize = size_of::<Bytes1>() + size_of::<Bytes32>() + size_of::<Bytes32>();
-pub type Buffer = [u8; BUFFER_SIZE];

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -2,4 +2,4 @@ mod hash;
 mod node;
 
 pub(crate) use hash::{empty_sum, zero_sum};
-pub(crate) use node::{Node, StorageNode};
+pub(crate) use node::{Buffer, Node, StorageNode};

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -4,9 +4,25 @@ use std::fmt;
 use std::mem::size_of;
 use std::ops::Range;
 
-use crate::common::{Buffer, Bytes1, Bytes32, LEAF, NODE};
+use crate::common::{Bytes1, Bytes32, Bytes4, LEAF, NODE};
 use crate::sparse::hash::sum;
 use crate::sparse::zero_sum;
+
+/// For a leaf:
+/// `00 - 04`: Height (4 bytes)
+/// `04 - 05`: Prefix (1 byte, 0x00),
+/// `05 - 37`: hash(Key) (32 bytes),
+/// `37 - 69`: hash(Data) (32 bytes)
+///
+/// For a node:
+/// `00 - 04`: Height (4 bytes)
+/// `04 - 05`: Prefix (1 byte, 0x01),
+/// `05 - 37`: Left child key (32 bytes),
+/// `37 - 69`: Right child key (32 bytes)
+///
+const BUFFER_SIZE: usize =
+    size_of::<Bytes4>() + size_of::<Bytes1>() + size_of::<Bytes32>() + size_of::<Bytes32>();
+pub type Buffer = [u8; BUFFER_SIZE];
 
 #[derive(Clone)]
 pub(crate) struct Node {
@@ -17,18 +33,20 @@ impl Node {
     pub fn create_leaf(key: &[u8], data: &[u8]) -> Self {
         let buffer = Self::default_buffer();
         let mut node = Self { buffer };
+        node.set_height(0);
         node.set_bytes_prefix(&[LEAF]);
         node.set_bytes_lo(&sum(key));
         node.set_bytes_hi(&sum(data));
         node
     }
 
-    pub fn create_node(left_child_key: &Bytes32, right_child_key: &Bytes32) -> Self {
+    pub fn create_node(left_child: &Node, right_child: &Node) -> Self {
         let buffer = Self::default_buffer();
         let mut node = Self { buffer };
+        node.set_height(left_child.height() + 1);
         node.set_bytes_prefix(&[NODE]);
-        node.set_bytes_lo(left_child_key);
-        node.set_bytes_hi(right_child_key);
+        node.set_bytes_lo(&left_child.hash());
+        node.set_bytes_hi(&right_child.hash());
         node
     }
 
@@ -41,6 +59,16 @@ impl Node {
         let node = Self { buffer };
         assert!(node.is_leaf() || node.is_node());
         node
+    }
+
+    pub fn height(&self) -> u32 {
+        let bytes = self.bytes_height();
+        u32::from_be_bytes(bytes.try_into().unwrap())
+    }
+
+    pub fn set_height(&mut self, height: u32) {
+        let bytes = height.to_be_bytes();
+        self.set_bytes_height(&bytes)
     }
 
     pub fn prefix(&self) -> u8 {
@@ -67,10 +95,6 @@ impl Node {
         self.bytes_hi().try_into().unwrap()
     }
 
-    pub fn height(&self) -> u32 {
-        todo!("https://github.com/FuelLabs/fuel-merkle/issues/59")
-    }
-
     pub fn is_leaf(&self) -> bool {
         self.prefix() == LEAF || self.is_placeholder()
     }
@@ -91,20 +115,35 @@ impl Node {
         if self.is_placeholder() {
             *zero_sum()
         } else {
-            sum(self.buffer())
+            let range = Self::hash_range();
+            sum(&self.buffer()[range])
         }
     }
 
     // PRIVATE
 
-    // PREFIX
-
     const fn default_buffer() -> Buffer {
         [0; Self::buffer_size()]
     }
 
-    const fn prefix_offset() -> usize {
+    // HEIGHT
+
+    const fn height_offset() -> usize {
         0
+    }
+
+    const fn height_size() -> usize {
+        size_of::<Bytes4>()
+    }
+
+    const fn height_range() -> Range<usize> {
+        Self::height_offset()..(Self::height_offset() + Self::height_size())
+    }
+
+    // PREFIX
+
+    const fn prefix_offset() -> usize {
+        Self::height_offset() + Self::height_size()
     }
 
     const fn prefix_size() -> usize {
@@ -143,10 +182,16 @@ impl Node {
         Self::bytes_hi_offset()..(Self::bytes_hi_offset() + Self::bytes_hi_size())
     }
 
+    // HASH
+
+    const fn hash_range() -> Range<usize> {
+        Self::prefix_offset()..Self::buffer_size()
+    }
+
     // BUFFER
 
     const fn buffer_size() -> usize {
-        Self::prefix_size() + Self::bytes_lo_size() + Self::bytes_hi_size()
+        BUFFER_SIZE
     }
 
     // PRIVATE
@@ -157,6 +202,20 @@ impl Node {
 
     fn buffer(&self) -> &[u8] {
         &self.buffer
+    }
+
+    fn bytes_height_mut(&mut self) -> &mut [u8] {
+        let range = Self::height_range();
+        &mut self.buffer_mut()[range]
+    }
+
+    fn bytes_height(&self) -> &[u8] {
+        let range = Self::height_range();
+        &self.buffer()[range]
+    }
+
+    fn set_bytes_height(&mut self, bytes: &Bytes4) {
+        self.bytes_height_mut().clone_from_slice(bytes)
     }
 
     fn bytes_prefix_mut(&mut self) -> &mut [u8] {
@@ -350,15 +409,24 @@ impl<'storage, StorageError> fmt::Debug for StorageNode<'storage, StorageError> 
 
 #[cfg(test)]
 mod test_node {
-    use crate::common::{LEAF, NODE};
+    use crate::common::{Bytes32, LEAF, NODE};
     use crate::sparse::hash::sum;
     use crate::sparse::{zero_sum, Node};
+
+    fn leaf_hash(key: &Bytes32, data: &Bytes32) -> Bytes32 {
+        let mut buffer = [0; 65];
+        buffer[0..1].clone_from_slice(&[LEAF]);
+        buffer[1..33].clone_from_slice(&sum(key));
+        buffer[33..65].clone_from_slice(&sum(data));
+        sum(&buffer)
+    }
 
     #[test]
     fn test_create_leaf_returns_a_valid_leaf() {
         let leaf = Node::create_leaf(&[1u8; 32], &[1u8; 32]);
         assert_eq!(leaf.is_leaf(), true);
         assert_eq!(leaf.is_node(), false);
+        assert_eq!(leaf.height(), 0);
         assert_eq!(leaf.prefix(), LEAF);
         assert_eq!(leaf.leaf_key(), &sum(&[1u8; 32]));
         assert_eq!(leaf.leaf_data(), &sum(&[1u8; 32]));
@@ -366,12 +434,15 @@ mod test_node {
 
     #[test]
     fn test_create_node_returns_a_valid_node() {
-        let node = Node::create_node(&[1u8; 32], &[1u8; 32]);
+        let left_child = Node::create_leaf(&[1u8; 32], &[1u8; 32]);
+        let right_child = Node::create_leaf(&[1u8; 32], &[1u8; 32]);
+        let node = Node::create_node(&left_child, &right_child);
         assert_eq!(node.is_leaf(), false);
         assert_eq!(node.is_node(), true);
+        assert_eq!(node.height(), 1);
         assert_eq!(node.prefix(), NODE);
-        assert_eq!(node.left_child_key(), &[1u8; 32]);
-        assert_eq!(node.right_child_key(), &[1u8; 32]);
+        assert_eq!(node.left_child_key(), &leaf_hash(&[1u8; 32], &[1u8; 32]));
+        assert_eq!(node.right_child_key(), &leaf_hash(&[1u8; 32], &[1u8; 32]));
     }
 
     #[test]
@@ -383,14 +454,16 @@ mod test_node {
 
     #[test]
     fn test_create_leaf_from_buffer_returns_a_valid_leaf() {
-        let mut buffer = [0u8; 65];
-        buffer[0..1].clone_from_slice(&[LEAF]);
-        buffer[1..33].clone_from_slice(&[1u8; 32]);
-        buffer[33..65].clone_from_slice(&[1u8; 32]);
+        let mut buffer = [0u8; 69];
+        buffer[0..4].clone_from_slice(&0_u32.to_be_bytes());
+        buffer[4..5].clone_from_slice(&[LEAF]);
+        buffer[5..37].clone_from_slice(&[1u8; 32]);
+        buffer[37..69].clone_from_slice(&[1u8; 32]);
 
         let node = Node::from_buffer(buffer);
         assert_eq!(node.is_leaf(), true);
         assert_eq!(node.is_node(), false);
+        assert_eq!(node.height(), 0);
         assert_eq!(node.prefix(), LEAF);
         assert_eq!(node.leaf_key(), &[1u8; 32]);
         assert_eq!(node.leaf_data(), &[1u8; 32]);
@@ -398,14 +471,16 @@ mod test_node {
 
     #[test]
     fn test_create_node_from_buffer_returns_a_valid_node() {
-        let mut buffer = [0u8; 65];
-        buffer[0..1].clone_from_slice(&[NODE]);
-        buffer[1..33].clone_from_slice(&[1u8; 32]);
-        buffer[33..65].clone_from_slice(&[1u8; 32]);
+        let mut buffer = [0u8; 69];
+        buffer[0..4].clone_from_slice(&256_u32.to_be_bytes());
+        buffer[4..5].clone_from_slice(&[NODE]);
+        buffer[5..37].clone_from_slice(&[1u8; 32]);
+        buffer[37..69].clone_from_slice(&[1u8; 32]);
 
         let node = Node::from_buffer(buffer);
         assert_eq!(node.is_leaf(), false);
         assert_eq!(node.is_node(), true);
+        assert_eq!(node.height(), 256);
         assert_eq!(node.prefix(), NODE);
         assert_eq!(node.left_child_key(), &[1u8; 32]);
         assert_eq!(node.right_child_key(), &[1u8; 32]);
@@ -414,10 +489,11 @@ mod test_node {
     #[test]
     #[should_panic]
     fn test_create_from_buffer_panics_if_invalid_prefix() {
-        let mut buffer = [0u8; 65];
-        buffer[0..1].clone_from_slice(&[0x02]);
-        buffer[1..33].clone_from_slice(&[1u8; 32]);
-        buffer[33..65].clone_from_slice(&[1u8; 32]);
+        let mut buffer = [0u8; 69];
+        buffer[0..4].clone_from_slice(&0_u32.to_be_bytes());
+        buffer[4..5].clone_from_slice(&[0x02]);
+        buffer[5..37].clone_from_slice(&[1u8; 32]);
+        buffer[37..69].clone_from_slice(&[1u8; 32]);
 
         // Should panic; prefix 0x02 is does not represent a node or leaf
         Node::from_buffer(buffer);
@@ -427,10 +503,11 @@ mod test_node {
     /// ```node.buffer = (0x00, k, h(serialize(d)))```
     #[test]
     fn test_leaf_buffer_returns_expected_buffer() {
-        let mut expected_buffer = [0u8; 65];
-        expected_buffer[0..1].clone_from_slice(&[LEAF]);
-        expected_buffer[1..33].clone_from_slice(&sum(&[1u8; 32]));
-        expected_buffer[33..65].clone_from_slice(&sum(&[1u8; 32]));
+        let mut expected_buffer = [0u8; 69];
+        expected_buffer[0..4].clone_from_slice(&0_u32.to_be_bytes());
+        expected_buffer[4..5].clone_from_slice(&[LEAF]);
+        expected_buffer[5..37].clone_from_slice(&sum(&[1u8; 32]));
+        expected_buffer[37..69].clone_from_slice(&sum(&[1u8; 32]));
 
         let leaf = Node::create_leaf(&[1u8; 32], &[1u8; 32]);
         let buffer = leaf.buffer();
@@ -442,12 +519,15 @@ mod test_node {
     /// ```node.buffer = (0x01, l.v, r.v)```
     #[test]
     fn test_node_buffer_returns_expected_buffer() {
-        let mut expected_buffer = [0u8; 65];
-        expected_buffer[0..1].clone_from_slice(&[NODE]);
-        expected_buffer[1..33].clone_from_slice(&[1u8; 32]);
-        expected_buffer[33..65].clone_from_slice(&[1u8; 32]);
+        let mut expected_buffer = [0u8; 69];
+        expected_buffer[0..4].clone_from_slice(&1_u32.to_be_bytes());
+        expected_buffer[4..5].clone_from_slice(&[NODE]);
+        expected_buffer[5..37].clone_from_slice(&leaf_hash(&[1u8; 32], &[1u8; 32]));
+        expected_buffer[37..69].clone_from_slice(&leaf_hash(&[1u8; 32], &[1u8; 32]));
 
-        let node = Node::create_node(&[1u8; 32], &[1u8; 32]);
+        let left_child = Node::create_leaf(&[1u8; 32], &[1u8; 32]);
+        let right_child = Node::create_leaf(&[1u8; 32], &[1u8; 32]);
+        let node = Node::create_node(&left_child, &right_child);
         let buffer = node.buffer();
 
         assert_eq!(buffer, expected_buffer);
@@ -475,11 +555,13 @@ mod test_node {
     fn test_node_hash_returns_expected_hash_value() {
         let mut expected_buffer = [0u8; 65];
         expected_buffer[0..1].clone_from_slice(&[NODE]);
-        expected_buffer[1..33].clone_from_slice(&[1u8; 32]);
-        expected_buffer[33..65].clone_from_slice(&[1u8; 32]);
+        expected_buffer[1..33].clone_from_slice(&leaf_hash(&[1u8; 32], &[1u8; 32]));
+        expected_buffer[33..65].clone_from_slice(&leaf_hash(&[1u8; 32], &[1u8; 32]));
         let expected_value = sum(&expected_buffer);
 
-        let node = Node::create_node(&[1u8; 32], &[1u8; 32]);
+        let left_child = Node::create_leaf(&[1u8; 32], &[1u8; 32]);
+        let right_child = Node::create_leaf(&[1u8; 32], &[1u8; 32]);
+        let node = Node::create_node(&left_child, &right_child);
         let value = node.hash();
 
         assert_eq!(value, expected_value);
@@ -503,7 +585,7 @@ mod test_storage_node {
         let leaf_1 = Node::create_leaf("Goodbye World".as_bytes(), &[1u8; 32]);
         let _ = s.insert(&leaf_1.hash(), leaf_1.as_buffer());
 
-        let node_0 = Node::create_node(&leaf_0.hash(), &leaf_1.hash());
+        let node_0 = Node::create_node(&leaf_0, &leaf_1);
         let _ = s.insert(&node_0.hash(), node_0.as_buffer());
 
         let storage_node = StorageNode::<StorageError>::new(&mut s, node_0);
@@ -522,7 +604,7 @@ mod test_storage_node {
         let leaf_1 = Node::create_leaf("Goodbye World".as_bytes(), &[1u8; 32]);
         let _ = s.insert(&leaf_1.hash(), leaf_1.as_buffer());
 
-        let node_0 = Node::create_node(&leaf_0.hash(), &leaf_1.hash());
+        let node_0 = Node::create_node(&leaf_0, &leaf_1);
         let _ = s.insert(&node_0.hash(), node_0.as_buffer());
 
         let storage_node = StorageNode::<StorageError>::new(&mut s, node_0);


### PR DESCRIPTION
Related issues:
- Closes https://github.com/FuelLabs/fuel-merkle/issues/59

This PR addresses an outstanding `todo` introduced in https://github.com/FuelLabs/fuel-merkle/pull/55.

This PR adds a height member to the Sparse Merkle Tree node. The node's underlying buffer has been extended by four bytes to accommodate a `u32` height field. The node's height is now stored inside the first four bytes, and the existing members (prefix, bytes lo, bytes hi) have been moved back. This makes the total buffer size 69 bytes.

While height is now part of the node's buffer, its height is not included in the node's hash. This means a node hash is still calculated as `h(0x01 | left_key | right_key)`. Instead of hashing the entire buffer, we simply hash a slice of the buffer at the relevant range.

Height is used during path traversal. The node's height in the tree indicates the index at which we start reading path traversal instructions (0 or 1) from the given leaf index. For sparse trees, we will often be traversing from the root to the leaf; this means a height of 256. Variable heights allow us to traverse from any given node to a leaf. 