### PR TITLE
Fix: Remove hashing from leaf keys in SMT Node

### DIFF
--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -43,8 +43,7 @@ impl Node {
     pub fn create_node(left_child: &Node, right_child: &Node) -> Self {
         let buffer = Self::default_buffer();
         let mut node = Self { buffer };
-        let height = std::cmp::max(left_child.height(), right_child.height()) + 1;
-        node.set_height(height);
+        node.set_height(left_child.height() + 1);
         node.set_prefix(NODE);
         node.set_bytes_lo(&left_child.hash());
         node.set_bytes_hi(&right_child.hash());

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -343,7 +343,7 @@ where
     }
 
     pub fn right_child(&self) -> Option<Self> {
-        assert!(self.is_node());
+        assert!(self.node.is_node());
         let key = self.node.right_child_key();
         let buffer = self.storage.get(key).unwrap();
         buffer.map(|b| {

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -304,7 +304,7 @@ impl fmt::Debug for Node {
 }
 
 type NodeStorage<'storage, StorageError> =
-dyn 'storage + Storage<Bytes32, Buffer, Error = StorageError>;
+    dyn 'storage + Storage<Bytes32, Buffer, Error = StorageError>;
 
 #[derive(Clone)]
 pub(crate) struct StorageNode<'storage, StorageError> {
@@ -313,8 +313,8 @@ pub(crate) struct StorageNode<'storage, StorageError> {
 }
 
 impl<'a, 'storage, StorageError> StorageNode<'storage, StorageError>
-    where
-        StorageError: std::error::Error + Clone,
+where
+    StorageError: std::error::Error + Clone,
 {
     pub fn new(storage: &'storage NodeStorage<'storage, StorageError>, node: Node) -> Self {
         Self { node, storage }
@@ -372,8 +372,8 @@ impl<'a, 'storage, StorageError> StorageNode<'storage, StorageError>
 }
 
 impl<'storage, StorageError> crate::common::Node for StorageNode<'storage, StorageError>
-    where
-        StorageError: std::error::Error + Clone,
+where
+    StorageError: std::error::Error + Clone,
 {
     type Key = Bytes32;
 
@@ -391,8 +391,8 @@ impl<'storage, StorageError> crate::common::Node for StorageNode<'storage, Stora
 }
 
 impl<'storage, StorageError> crate::common::ParentNode for StorageNode<'storage, StorageError>
-    where
-        StorageError: std::error::Error + Clone,
+where
+    StorageError: std::error::Error + Clone,
 {
     fn left_child(&self) -> Self {
         StorageNode::left_child(self).unwrap()


### PR DESCRIPTION
The current SMT implementation hashes keys provided by calls to `update` and `delete`. The [SMT spec](https://github.com/celestiaorg/celestia-specs/blob/master/src/specs/data_structures.md#sparse-merkle-tree) mandates leaves use the raw 32 byte key input, rather than the hash of the key input. This means clients are able to decide on the algorithm that produces 32 byte keys. 

This behaviour is an artifact of the Celestia SMT implementation. Both the Celestia implementation and the Fuel implementation are moving towards an SMT interface that takes in 32 byte keys for `update` and `delete` functions.

In this PR, I am changing the internal SMT node structure so that leaves are constructed using raw 32 byte keys. The [WIP SMT PR](https://github.com/FuelLabs/fuel-merkle/pull/41) has been similarly modified to expose the correct `update` and `delete` interface using 32 byte keys. I am also including minor changes to the Node structure from the SMT PR in this PR.