### PR TITLE
Refactor: Add method to SMT node to set prefix

### DIFF
--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -348,7 +348,7 @@ where
     }
 
     pub fn right_child(&self) -> Option<Self> {
-        assert!(self.is_node());
+        assert!(self.node.is_node());
         let key = self.node.right_child_key();
         let buffer = self.storage.get(key).unwrap();
         buffer.map(|b| {

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -34,7 +34,7 @@ impl Node {
         let buffer = Self::default_buffer();
         let mut node = Self { buffer };
         node.set_height(0);
-        node.set_bytes_prefix(&[LEAF]);
+        node.set_prefix(LEAF);
         node.set_bytes_lo(key);
         node.set_bytes_hi(&sum(data));
         node
@@ -44,7 +44,7 @@ impl Node {
         let buffer = Self::default_buffer();
         let mut node = Self { buffer };
         node.set_height(left_child.height() + 1);
-        node.set_bytes_prefix(&[NODE]);
+        node.set_prefix(NODE);
         node.set_bytes_lo(&left_child.hash());
         node.set_bytes_hi(&right_child.hash());
         node
@@ -73,6 +73,11 @@ impl Node {
 
     pub fn prefix(&self) -> u8 {
         self.bytes_prefix()[0]
+    }
+
+    pub fn set_prefix(&mut self, prefix: u8) {
+        let bytes = prefix.to_be_bytes();
+        self.set_bytes_prefix(&bytes);
     }
 
     pub fn leaf_key(&self) -> &Bytes32 {
@@ -343,7 +348,7 @@ where
     }
 
     pub fn right_child(&self) -> Option<Self> {
-        assert!(self.node.is_node());
+        assert!(self.is_node());
         let key = self.node.right_child_key();
         let buffer = self.storage.get(key).unwrap();
         buffer.map(|b| {


### PR DESCRIPTION
Minor refactor to SMT Node to provide interface for setting the node prefix. This allows setting the node prefix by specifying the prefix bit, rather than the prefix bit as an array. This PR introduces no functional changes.