### PR TITLE
Feat: Add height to SMT node debug

### DIFF
--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -391,7 +391,10 @@ where
     }
 }
 
-impl<'storage, StorageError> fmt::Debug for StorageNode<'storage, StorageError> {
+impl<'storage, StorageError> fmt::Debug for StorageNode<'storage, StorageError>
+where
+    StorageError: std::error::Error + Clone,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.node.is_node() {
             f.debug_struct("StorageNode (Internal)")

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -281,12 +281,14 @@ impl fmt::Debug for Node {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_node() {
             f.debug_struct("Node (Internal)")
+                .field("Height", &self.height())
                 .field("Hash", &hex::encode(self.hash()))
                 .field("Left child key", &hex::encode(self.left_child_key()))
                 .field("Right child key", &hex::encode(self.right_child_key()))
                 .finish()
         } else {
             f.debug_struct("Node (Leaf)")
+                .field("Height", &self.height())
                 .field("Hash", &hex::encode(self.hash()))
                 .field("Leaf key", &hex::encode(self.leaf_key()))
                 .field("Leaf data", &hex::encode(self.leaf_data()))
@@ -393,12 +395,14 @@ impl<'storage, StorageError> fmt::Debug for StorageNode<'storage, StorageError> 
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.node.is_node() {
             f.debug_struct("StorageNode (Internal)")
+                .field("Height", &self.height())
                 .field("Hash", &hex::encode(self.node.hash()))
                 .field("Left child key", &hex::encode(self.node.left_child_key()))
                 .field("Right child key", &hex::encode(self.node.right_child_key()))
                 .finish()
         } else {
             f.debug_struct("StorageNode (Leaf)")
+                .field("Height", &self.height())
                 .field("Hash", &hex::encode(self.node.hash()))
                 .field("Leaf key", &hex::encode(self.node.leaf_key()))
                 .field("Leaf data", &hex::encode(self.node.leaf_data()))

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -396,17 +396,17 @@ where
     StorageError: std::error::Error + Clone,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.node.is_node() {
+        if self.is_node() {
             f.debug_struct("StorageNode (Internal)")
                 .field("Height", &self.height())
-                .field("Hash", &hex::encode(self.node.hash()))
+                .field("Hash", &hex::encode(self.hash()))
                 .field("Left child key", &hex::encode(self.node.left_child_key()))
                 .field("Right child key", &hex::encode(self.node.right_child_key()))
                 .finish()
         } else {
             f.debug_struct("StorageNode (Leaf)")
                 .field("Height", &self.height())
-                .field("Hash", &hex::encode(self.node.hash()))
+                .field("Hash", &hex::encode(self.hash()))
                 .field("Leaf key", &hex::encode(self.node.leaf_key()))
                 .field("Leaf data", &hex::encode(self.node.leaf_data()))
                 .finish()


### PR DESCRIPTION
Adds a field for displaying `height` when debugging an SMT `Node` or `StorageNode`. When debugging with a call like 
```
println!("{:?}")
```
it will output something like:
```
Node (Internal) { Height: 1, Hash: "eda830b210c5332b6d899718c55d04eaa942d99a70deaa6e39905eb393edd480", Left child key: "40fec866539985c2212facbbbde0477e92700fa0b96614c239add059b8812e2a", Right child key: "e08d1bf00caa0f7ebdb18f922519c02c7e613a5d63e0ede94b6b6657ed1713b6" }
```

This is useful when debugging the SMT implementation. For example, when setting the SMT root, it is necessary that the supplied node has a height of 256.