### PR TITLE
Fix: SMT Node `left_child` and `right_child` return placeholder when key is zero sum

### DIFF
--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -335,6 +335,9 @@ where
     pub fn left_child(&self) -> Option<Self> {
         assert!(self.is_node());
         let key = self.node.left_child_key();
+        if key == zero_sum() {
+            return Some(Self::new(self.storage, Node::create_placeholder()));
+        }
         let buffer = self.storage.get(key).unwrap();
         buffer.map(|b| {
             let node = Node::from_buffer(*b);
@@ -343,8 +346,11 @@ where
     }
 
     pub fn right_child(&self) -> Option<Self> {
-        assert!(self.node.is_node());
+        assert!(self.is_node());
         let key = self.node.right_child_key();
+        if key == zero_sum() {
+            return Some(Self::new(self.storage, Node::create_placeholder()));
+        }
         let buffer = self.storage.get(key).unwrap();
         buffer.map(|b| {
             let node = Node::from_buffer(*b);

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -622,4 +622,36 @@ mod test_storage_node {
 
         assert_eq!(child.hash(), leaf_1.hash());
     }
+
+    #[test]
+    fn test_node_left_child_returns_placeholder_when_key_is_zero_sum() {
+        let mut s = StorageMap::<Bytes32, Buffer>::new();
+
+        let leaf = Node::create_leaf(&sum(b"Goodbye World"), &[1u8; 32]);
+        let _ = s.insert(&leaf.hash(), leaf.as_buffer());
+
+        let node_0 = Node::create_node(&Node::create_placeholder(), &leaf);
+        let _ = s.insert(&node_0.hash(), node_0.as_buffer());
+
+        let storage_node = StorageNode::<StorageError>::new(&mut s, node_0);
+        let child = storage_node.left_child().unwrap();
+
+        assert!(child.node.is_placeholder());
+    }
+
+    #[test]
+    fn test_node_right_child_returns_placeholder_when_key_is_zero_sum() {
+        let mut s = StorageMap::<Bytes32, Buffer>::new();
+
+        let leaf = Node::create_leaf(&sum(b"Goodbye World"), &[1u8; 32]);
+        let _ = s.insert(&leaf.hash(), leaf.as_buffer());
+
+        let node_0 = Node::create_node(&leaf, &Node::create_placeholder());
+        let _ = s.insert(&node_0.hash(), node_0.as_buffer());
+
+        let storage_node = StorageNode::<StorageError>::new(&mut s, node_0);
+        let child = storage_node.right_child().unwrap();
+
+        assert!(child.node.is_placeholder());
+    }
 }


### PR DESCRIPTION
When retrieving a left child or right child from an SMT node, we must accommodate the case when the child is a placeholder. The placeholder node is a node with the zero sum key (`000...`). In the current design, all children must be present in the underlying data store; this includes placeholders. This assumes that the store will be initialized with a zero-sum key mapped to a placeholder, i.e.
```
...
let zero_sum_key = zero_sum()
assert!(storage[zero_sum_key].is_placeholder())
```

This has a few important drawbacks:
- The store must be initialized properly to handle this edge case. This means a storage write when initializing an SMT
- Reading a zero sum key incurs a round trip to the store, when the child can be resolved client side
- Deleting path nodes or side nodes may involve deleting a placeholder; this will leave the storage in an invalid state as no further placeholders can be loaded

These drawbacks are all neatly resolved by ensuring that a placeholder is retuned when encountering a zero sum key at the library level.