### PR TITLE
Fix: When creating internal SMT node, set height to be the greater height of left and right children

### DIFF
--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -43,8 +43,9 @@ impl Node {
     pub fn create_node(left_child: &Node, right_child: &Node) -> Self {
         let buffer = Self::default_buffer();
         let mut node = Self { buffer };
-        node.set_height(left_child.height() + 1);
-        node.set_prefix(NODE);
+        let height = std::cmp::max(left_child.height(), right_child.height()) + 1;
+        node.set_height(height);
+        node.set_bytes_prefix(&[NODE]);
         node.set_bytes_lo(&left_child.hash());
         node.set_bytes_hi(&right_child.hash());
         node


### PR DESCRIPTION
When creating an internal SMT node by merging two child nodes, the height of the merged node is equal to the height of highest child node plus 1. This is not reflected in the current implementation.

Currently, the `create_node` method assumes that the left child will always have the greater height of the left and right children. This is an artifact of the binary Merkle tree implementation where this assumption holds true. In a sparse Merkle tree, it is possible that either the left or right child will have the greater height. 