### PR TITLE
Docs: Fix expected root in SMT root test pseudocode example

### DIFF
--- a/docs/test-specs/sparse_merkle_tree_tests.md
+++ b/docs/test-specs/sparse_merkle_tree_tests.md
@@ -3,7 +3,7 @@
 ## Version
 0.1.0
 
-Last updated 2022/02/25
+Last updated 2022/03/04
 
 ## Abstract
 

--- a/docs/test-specs/sparse_merkle_tree_tests.md
+++ b/docs/test-specs/sparse_merkle_tree_tests.md
@@ -412,7 +412,6 @@ root = smt.root()
 expected_root = '0000000000000000000000000000000000000000000000000000000000000000'
 expect(hex_encode(root), expected_root).to_be_equal
 ```
-
 ---
 
 ### Test Update 1 Delete 1
@@ -534,7 +533,6 @@ root = smt.root()
 expected_root = '108f731f2414e33ae57e584dc26bd276db07874436b2264ca6e520c658185c6b'
 expect(hex_encode(root), expected_root).to_be_equal
 ```
-
 ---
 
 ### Test Interleaved Update Delete

--- a/docs/test-specs/sparse_merkle_tree_tests.md
+++ b/docs/test-specs/sparse_merkle_tree_tests.md
@@ -354,7 +354,7 @@ for i in 0..5 {
     smt.update(&sum(key), data)
 }
 root = smt.root()
-expected_root = 'e02e761efef33aaa7a7027b4f5596c4c860476f299cdd0c4555199292d5041ee'
+expected_root = 'e912e97abc67707b2e6027338292943b53d01a7fbd7b244674128c7e468dd696'
 expect(hex_encode(root), expected_root).to_be_equal
 ```
 ---


### PR DESCRIPTION
For the test `Test Update Sparse Union`, there is a discrepancy between the expected root in the test spec, and the expected root in the test pseudocode. This appears to have been caused by committing a cardinal sin: copying + pasting a previous test case. The test spec specifies the correct root, while the pseudocode example uses an old root. This PR fixes that so that both instances reflect the correct root.