### PR TITLE
Feat: Refactor BMT and SMT interfaces to use `anyhow::Result`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/FuelLabs/fuel-merkle"
 description = "Fuel Merkle tree libraries."
 
 [dependencies]
+anyhow = "1.0"
 bytes = "1.0"
 digest = "0.9"
 fuel-storage = "0.1"


### PR DESCRIPTION
Related issues:
- Closes https://github.com/FuelLabs/fuel-merkle/issues/84

This PR updates the BMT and SMT interfaces to return `anyhow::Result` instead of the core `Result`. `anyhow::Result` is almost a drop-in replacement for `Result<T, Box<dyn std::error::Error>>` but allows us to omit the boxed error trait object. This gives us a cleaner, more readable interface.

According to https://docs.rs/anyhow/latest/anyhow/:
- `anyhow::Result` is equivalent to `Result<T, anyhow::Error>`
- `anyhow::Error` works a lot like `Box<dyn std::error::Error>`, but with these differences:
  - Error requires that the error is `Send`, `Sync`, and `'static`.
  - Error guarantees that a backtrace is available, even if the underlying error type does not provide one.
  - Error is represented as a narrow pointer — exactly one word in size instead of two.
 
Therefore, this refactor requires adding `Send` and `Sync` to the trait requirements of the Merkle tree's `Error`.