### PR TITLE
Chore: Refactor comment length to maximum of 80

### DIFF
--- a/src/common/position.rs
+++ b/src/common/position.rs
@@ -2,15 +2,16 @@ use crate::common::{Bytes8, PositionPath};
 
 /// #Position
 ///
-/// A `Position` represents a node's position in a binary tree by encapsulating the node's index
-/// data. Indices are calculated through in-order traversal of the nodes, starting with the first
-/// leaf node. Indexing starts at 0.
+/// A `Position` represents a node's position in a binary tree by encapsulating
+/// the node's index data. Indices are calculated through in-order traversal of
+/// the nodes, starting with the first leaf node. Indexing starts at 0.
 ///
 /// ##Merkle Trees
 ///
-/// In the context of Merkle trees, trees are constructed "upwards" from leaf nodes. Therefore,
-/// traversal is done from the bottom up, starting with the leaves, rather than top down, starting
-/// with the root, and we can guarantee a deterministic construction of index data.
+/// In the context of Merkle trees, trees are constructed "upwards" from leaf
+/// nodes. Therefore, traversal is done from the bottom up, starting with the
+/// leaves, rather than top down, starting with the root, and we can guarantee a
+/// deterministic construction of index data.
 ///
 /// ```text
 ///               07
@@ -28,11 +29,13 @@ use crate::common::{Bytes8, PositionPath};
 /// 00  02  04  06  08  10  12  14
 /// ```
 ///
-/// In-order indices can be considered internal to the `Position` struct and are used to facilitate
-/// the calculation of positional attributes and the construction of other nodes. Leaf nodes have
-/// both an in-order index as part of the tree, and a leaf index determined by its position in the
-/// bottom row. Because of the in-order traversal used to calculate the in-order indices, leaf nodes
-/// have the property that their in-order index is always equal to their leaf index multiplied by 2.
+/// In-order indices can be considered internal to the `Position` struct and are
+/// used to facilitate the calculation of positional attributes and the
+/// construction of other nodes. Leaf nodes have both an in-order index as part
+/// of the tree, and a leaf index determined by its position in the bottom row.
+/// Because of the in-order traversal used to calculate the in-order indices,
+/// leaf nodes have the property that their in-order index is always equal to
+/// their leaf index multiplied by 2.
 ///
 /// ```text
 ///                    /  \    /  \    /  \    /  \
@@ -40,19 +43,21 @@ use crate::common::{Bytes8, PositionPath};
 /// In-order indices: 00  02  04  06  08  10  12  14
 /// ```
 ///
-/// This allows us to construct a `Position` (and its in-order index) by providing either an
-/// in-order index directly or, in the case of a leaf, a leaf index. This functionality is captured
-/// by `from_in_order_index()` and `from_leaf_index()` respectively.
+/// This allows us to construct a `Position` (and its in-order index) by
+/// providing either an in-order index directly or, in the case of a leaf, a
+/// leaf index. This functionality is captured by `from_in_order_index()` and
+/// `from_leaf_index()` respectively.
 ///
-/// Traversal of a Merkle Tree can be performed by the methods on a given `Position` to retrieve its
-/// sibling, parent, or uncle `Position`.
+/// Traversal of a Merkle Tree can be performed by the methods on a given
+/// `Position` to retrieve its sibling, parent, or uncle `Position`.
 ///
 /// ##Merkle Mountain Ranges
 ///
-/// Because the `Position` indices are calculated from in-order traversal starting with the leaves,
-/// the deterministic quality of the indices holds true for imbalanced binary trees, including
-/// Merle Mountain Ranges. Consider the following binary tree construction comprised of seven
-/// leaves (with leaf indices 0 through 6):
+/// Because the `Position` indices are calculated from in-order traversal
+/// starting with the leaves, the deterministic quality of the indices holds
+/// true for imbalanced binary trees, including Merle Mountain Ranges. Consider
+/// the following binary tree construction comprised of seven leaves (with leaf
+/// indices 0 through 6):
 ///
 /// ```text
 ///       03
@@ -63,14 +68,15 @@ use crate::common::{Bytes8, PositionPath};
 /// 00  02  04  06  08  10  12
 /// ```
 ///
-/// Note the absence of internal nodes that would be present in a fully balanced tree: inner nodes
-/// with indices 7 and 11 are absent. This is owing to the fact that node indices are calculated
-/// deterministically through in-order traversal, not calculated as a sequence.
+/// Note the absence of internal nodes that would be present in a fully balanced
+/// tree: inner nodes with indices 7 and 11 are absent. This is owing to the
+/// fact that node indices are calculated deterministically through in-order
+/// traversal, not calculated as a sequence.
 ///
-/// Traversal of a Merkle Mountain Range is still done in the same manner as a balanced Merkle tree,
-/// using methods to retrieve a `Position's` sibling, parent, or uncle `Position`. However, in such
-/// cases, the corresponding sibling or uncle nodes are not guaranteed to exist in the tree.
-///
+/// Traversal of a Merkle Mountain Range is still done in the same manner as a
+/// balanced Merkle tree, using methods to retrieve a `Position's` sibling,
+/// parent, or uncle `Position`. However, in such cases, the corresponding
+/// sibling or uncle nodes are not guaranteed to exist in the tree.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Position(u64);
 
@@ -92,8 +98,8 @@ impl Position {
         Position(index)
     }
 
-    /// Construct a position from a leaf index. The in-order index corresponding to the leaf index
-    /// will always equal the leaf index multiplied by 2.
+    /// Construct a position from a leaf index. The in-order index corresponding
+    /// to the leaf index will always equal the leaf index multiplied by 2.
     pub fn from_leaf_index(index: u64) -> Self {
         Position(index * 2)
     }
@@ -115,8 +121,8 @@ impl Position {
     }
 
     /// The uncle position.
-    /// The uncle position is the sibling of the parent and has a height less 1 relative to this
-    /// position.
+    /// The uncle position is the sibling of the parent and has a height less 1
+    /// relative to this position.
     pub fn uncle(self) -> Self {
         self.parent().sibling()
     }
@@ -137,9 +143,10 @@ impl Position {
     /// Leaf nodes represent height 0. A leaf's parent represents height 1.
     /// Height values monotonically increase as you ascend the tree.
     ///
-    /// Height is deterministically calculated as the number of trailing zeros of the complement of
-    /// the position's index. The following table demonstrates the relationship between a position's
-    /// height and the trailing zeros.
+    /// Height is deterministically calculated as the number of trailing zeros
+    /// of the complement of the position's index. The following table
+    /// demonstrates the relationship between a position's height and the
+    /// trailing zeros.
     ///
     /// | Index (Dec) | Index (Bin) | !Index (Bin) | Trailing 0s | Height |
     /// |-------------|-------------|--------------|-------------|--------|
@@ -151,7 +158,6 @@ impl Position {
     /// |           9 |        1001 |         0110 |           1 |      1 |
     /// |           3 |        0011 |         1100 |           2 |      2 |
     /// |          11 |        1011 |         0100 |           2 |      2 |
-    ///
     pub fn height(self) -> u32 {
         (!self.in_order_index()).trailing_zeros()
     }
@@ -160,8 +166,9 @@ impl Position {
     /// Returns `true` if the position is a leaf node.
     /// Returns `false` if the position is an internal node.
     ///
-    /// A position is a leaf node if and only if its in-order index is even. A position is an
-    /// internal node if and only if its in-order index is odd.
+    /// A position is a leaf node if and only if its in-order index is even. A
+    /// position is an internal node if and only if its in-order index is
+    /// odd.
     pub fn is_leaf(self) -> bool {
         self.in_order_index() % 2 == 0
     }
@@ -170,15 +177,16 @@ impl Position {
     /// Returns `false` if the position is a leaf node.
     /// Returns `true` if the position is an internal node.
     ///
-    /// When a position is an internal node, the position will have both a left and right child.
+    /// When a position is an internal node, the position will have both a left
+    /// and right child.
     pub fn is_node(self) -> bool {
         !self.is_leaf()
     }
 
-    /// Given a leaf position and the total count of leaves in a tree, get the path from this
-    /// position to the given leaf position. The shape of the tree is defined by the `leaves_count`
-    /// parameter and constrains the path.
-    /// See [PositionPath](crate::common::PositionPath).
+    /// Given a leaf position and the total count of leaves in a tree, get the
+    /// path from this position to the given leaf position. The shape of the
+    /// tree is defined by the `leaves_count` parameter and constrains the
+    /// path. See [PositionPath](crate::common::PositionPath).
     pub fn path(self, leaf: &Self, leaves_count: u64) -> PositionPath {
         PositionPath::new(self, *leaf, leaves_count)
     }
@@ -186,13 +194,15 @@ impl Position {
     // PRIVATE
 
     /// The child position of the current position given by the direction.
-    /// A direction of `-1` denotes the left child. A direction of `+1` denotes the right child. A
-    /// child position has a height less 1 than the current position.
+    /// A direction of `-1` denotes the left child. A direction of `+1` denotes
+    /// the right child. A child position has a height less 1 than the
+    /// current position.
     ///
-    /// A child position is calculated as a function of the current position's index and height, and
-    /// the supplied direction. The left child position has the in-order index arriving before the
-    /// current index; the right child position has the in-order index arriving after the current
-    /// index.
+    /// A child position is calculated as a function of the current position's
+    /// index and height, and the supplied direction. The left child
+    /// position has the in-order index arriving before the current index;
+    /// the right child position has the in-order index arriving after the
+    /// current index.
     fn child(self, direction: i64) -> Self {
         assert!(self.is_node());
         let shift = 1 << (self.height() - 1);
@@ -204,9 +214,10 @@ impl Position {
     /// Returns 0 if the index is left of its parent.
     /// Returns 1 if the index is right of its parent.
     ///
-    /// The orientation is determined by the reading the `n`th rightmost digit of the index's binary
-    /// value, where `n` = the height of the position + 1. The following table demonstrates the
-    /// relationships between a position's index, height, and orientation.
+    /// The orientation is determined by the reading the `n`th rightmost digit
+    /// of the index's binary value, where `n` = the height of the position
+    /// + 1. The following table demonstrates the relationships between a
+    /// position's index, height, and orientation.
     ///
     /// | Index (Dec) | Index (Bin) | Height | Orientation |
     /// |-------------|-------------|--------|-------------|
@@ -218,7 +229,6 @@ impl Position {
     /// |           5 |        0101 |      1 |           1 |
     /// |           9 |        1001 |      1 |           0 |
     /// |          13 |        1101 |      1 |           1 |
-    ///
     fn orientation(self) -> u8 {
         let shift = 1 << (self.height() + 1);
         (self.in_order_index() & shift != 0) as u8

--- a/src/common/position_path.rs
+++ b/src/common/position_path.rs
@@ -3,18 +3,19 @@ use crate::common::{AsPathIterator, Position};
 
 /// #PositionPath
 ///
-/// A PositionPath represents the path of positions created by traversing a binary tree from the
-/// root position to the leaf position. The shape of the tree determines path traversal, and can be
-/// described accurately by the number of leaves comprising the tree. For example, traversing to the
-/// fifth leaf of a balanced eight-leaf tree will generate a different path than traversing to the
-/// fifth leaf of an imbalanced five-leaf tree.
+/// A PositionPath represents the path of positions created by traversing a
+/// binary tree from the root position to the leaf position. The shape of the
+/// tree determines path traversal, and can be described accurately by the
+/// number of leaves comprising the tree. For example, traversing to the fifth
+/// leaf of a balanced eight-leaf tree will generate a different path than
+/// traversing to the fifth leaf of an imbalanced five-leaf tree.
 ///
-/// A PositionPath exposes an `iter()` method for performing iteration on this path. Each iteration
-/// returns a tuple containing the next position in the path and the corresponding side node.
-/// Because the tree may be imbalanced, as described by the path's `leaves_count` parameter, the
-/// side node may not necessarily be the direct sibling of the path node; rather, it can be a
+/// A PositionPath exposes an `iter()` method for performing iteration on this
+/// path. Each iteration returns a tuple containing the next position in the
+/// path and the corresponding side node. Because the tree may be imbalanced, as
+/// described by the path's `leaves_count` parameter, the side node may not
+/// necessarily be the direct sibling of the path node; rather, it can be a
 /// position at a lower spot in the tree altogether.
-///
 pub struct PositionPath {
     root: Position,
     leaf: Position,
@@ -56,35 +57,41 @@ impl Iterator for PositionPathIter {
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some((path, mut side)) = self.path_iter.next() {
-            // To determine if the position is in the tree, we observe that the highest in-order
-            // index belongs to the tree's rightmost leaf position (as defined by the `leaves_count`
-            // parameter) and that all path nodes will have an in-order index less than or equal to
-            // the in-order index of this rightmost leaf position.
-            // If a path position has an in-order index greater than that of the rightmost leaf
-            // position, it is invalid in the context of this tree and must be discarded. However,
-            // the corresponding side node is valid (or is the ancestor of a valid side node) and
-            // represents the side node of a deeper path position that is also valid (i.e., has an
-            // in-order index less than or equal to that of the rightmost leaf). We can save
-            // reference to it now so that we can generate the path node and side node pair later,
-            // once both nodes are encountered.
+            // To determine if the position is in the tree, we observe that the
+            // highest in-order index belongs to the tree's rightmost leaf
+            // position (as defined by the `leaves_count` parameter) and that
+            // all path nodes will have an in-order index less than or equal to
+            // the in-order index of this rightmost leaf position. If a path
+            // position has an in-order index greater than that of the rightmost
+            // leaf position, it is invalid in the context of this tree and must
+            // be discarded. However, the corresponding side node is valid (or
+            // is the ancestor of a valid side node) and represents the side
+            // node of a deeper path position that is also valid (i.e., has
+            // in-order index less than or equal to that of the rightmost leaf).
+            // We can save reference to it now so that we can generate the path
+            // node and side node pair later, once both nodes are encountered.
             if path.in_order_index() <= self.rightmost_position.in_order_index() {
-                // If we previously encountered a side node corresponding to an invalid path node,
-                // we observe that the next valid path node always pairs with this side node. Once
-                // the path and side node have been paired, we continue to pair path and side nodes
+                // If we previously encountered a side node corresponding to an
+                // invalid path node, we observe that the next valid path node
+                // always pairs with this side node. Once the path and side node
+                // have been paired, we continue to pair path  and side nodes
                 // normally.
                 side = self.current_side_node.take().unwrap_or(side);
 
-                // A side node with an in-order index greater than the index of the rightmost leaf
-                // position is invalid and does not exist in the context of this tree. The invalid
-                // side node will always be the ancestor of the correct side node. Furthermore, the
-                // correct side node will always be a leftward descendent of this invalid side node.
+                // A side node with an in-order index greater than the index of
+                // the rightmost leaf position is invalid and does not exist in
+                // the context of this tree. The invalid side node will always
+                // be the ancestor of the correct side node. Furthermore, the
+                // correct side node will always be a leftward descendent of
+                // this invalid side node.
                 while side.in_order_index() > self.rightmost_position.in_order_index() {
                     side = side.left_child()
                 }
 
                 return Some((path, side));
             } else {
-                // If the path node is invalid, save reference to the the corresponding side node.
+                // If the path node is invalid, save reference to the the corresponding side
+                // node.
                 if self.current_side_node.is_none() {
                     self.current_side_node = Some(side);
                 }

--- a/src/sparse/merkle_tree.rs
+++ b/src/sparse/merkle_tree.rs
@@ -45,7 +45,8 @@ where
 
     pub fn update(&'a mut self, key: &Bytes32, data: &[u8]) -> Result<()> {
         if data.is_empty() {
-            // If the data is empty, this signifies a delete operation for the given key.
+            // If the data is empty, this signifies a delete operation for the
+            // given key.
             self.delete(key)?;
             return Ok(());
         }
@@ -68,7 +69,8 @@ where
 
     pub fn delete(&'a mut self, key: &Bytes32) -> Result<()> {
         if self.root() == *zero_sum() {
-            // The zero root signifies that all leaves are empty, including the given key.
+            // The zero root signifies that all leaves are empty, including the
+            // given key.
             return Ok(());
         }
 
@@ -123,21 +125,26 @@ where
         // Build the tree upwards starting with the requested leaf node.
         let mut current_node = requested_leaf_node.clone();
 
-        // If we are creating a new leaf node, the corresponding side node will be the first node in
-        // the path set. The side node will be the leaf node currently closest to the requested new
-        // leaf node. When creating a new leaf node, we must merge the leaf node with its
-        // corresponding side node to create a common ancestor. We then continue building the tree
-        // upwards from this ancestor node. This may require creating new placeholder side nodes, in
-        // addition to the existing side node set.
-        // If we are updating an existing leaf node, the leaf node we are updating is the first node
-        // in the path set. The side node set will already include all the side nodes needed to
-        // build up the tree from the requested leaf node, since these side nodes were already built
+        // If we are creating a new leaf node, the corresponding side node will
+        // be the first node in the path set. The side node will be the leaf
+        // node currently closest to the requested new leaf node. When creating
+        // a new leaf node, we must merge the leaf node with its corresponding
+        // side node to create a common ancestor. We then continue building the
+        // tree upwards from this ancestor node. This may require creating new
+        // placeholder side nodes, in addition to the existing side node set.
+        //
+        // If we are updating an existing leaf node, the leaf node we are
+        // updating is the first node in the path set. The side node set will
+        // already include all the side nodes needed to build up the tree from
+        // the requested leaf node, since these side nodes were already built
         // during the creation of the leaf node.
-        // We can determine if we are updating an existing leaf node, or if we are creating a new
-        // leaf node, by comparing the paths of the requested leaf node and the leaf node at the
-        // start of the path set. When the paths are equal, it means the leaf nodes occupy the same
-        // location, and we are updating an existing leaf. Otherwise, it means we are adding a new
-        // leaf node.
+        //
+        // We can determine if we are updating an existing leaf node, or if we
+        // are creating a new leaf node, by comparing the paths of the requested
+        // leaf node and the leaf node at the start of the path set. When the
+        // paths are equal, it means the leaf nodes occupy the same location,
+        // and we are updating an existing leaf. Otherwise, it means we are
+        // adding a new leaf node.
         if requested_leaf_node.leaf_key() != actual_leaf_node.leaf_key() {
             // Merge leaves
             if !actual_leaf_node.is_placeholder() {
@@ -184,31 +191,35 @@ where
         let path = requested_leaf_node.leaf_key();
         let mut side_nodes_iter = side_nodes.iter();
 
-        // The deleted leaf is replaced by a placeholder. Build the tree upwards starting with the
-        // placeholder.
+        // The deleted leaf is replaced by a placeholder. Build the tree upwards
+        // starting with the placeholder.
         let mut current_node = Node::create_placeholder();
 
-        // If the first side node is a leaf, it means the ancestor node is now parent to a
-        // placeholder (the deleted leaf node) and a leaf node (the first side node). We can
-        // immediately discard the ancestor node from further calculation and attach the orphaned
-        // leaf node to its next ancestor. Any subsequent ancestor nodes composed of this leaf node
-        // and a placeholder must be similarly discarded from further calculation. We then create a
-        // valid ancestor node for the orphaned leaf node by joining it with the earliest
-        // non-placeholder side node.
+        // If the first side node is a leaf, it means the ancestor node is now
+        // parent to a placeholder (the deleted leaf node) and a leaf node (the
+        // first side node). We can immediately discard the ancestor node from
+        // further calculation and attach the orphaned leaf node to its next
+        // ancestor. Any subsequent ancestor nodes composed of this leaf node
+        // and a placeholder must be similarly discarded from further
+        // calculation. We then create a valid ancestor node for the orphaned
+        // leaf node by joining it with the earliest non-placeholder side node.
         let first_side_node = side_nodes.first();
         if first_side_node.is_some() && first_side_node.unwrap().is_leaf() {
             side_nodes_iter.next();
             current_node = first_side_node.unwrap().clone();
 
-            // Advance the side node iterator to the next non-placeholder node. This may be either
-            // another leaf node or an internal node.
-            // If only placeholder nodes exist beyond the first leaf node, then that leaf node is,
-            // in fact, the new root node.
-            // Using `find(..)` advances the iterator beyond the next non-placeholder side node and
-            // returns it. Therefore, we must consume the side node at this point. If another
-            // non-placeholder node was found in the side node collection, merge it with the first
-            // side node. This guarantees that the current node will be an internal node, and
-            // not a leaf, by the time we start merging the remaining side nodes.
+            // Advance the side node iterator to the next non-placeholder node.
+            // This may be either another leaf node or an internal node. If only
+            // placeholder nodes exist beyond the first leaf node, then that
+            // leaf node is, in fact, the new root node.
+            //
+            // Using `find(..)` advances the iterator beyond the next
+            // non-placeholder side node and returns it. Therefore, we must
+            // consume the side node at this point. If another non-placeholder
+            // node was found in the side node collection, merge it with the
+            // first side node. This guarantees that the current node will be an
+            // internal node, and not a leaf, by the time we start merging the
+            // remaining side nodes.
             // See https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.find.
             if let Some(side_node) = side_nodes_iter.find(|side_node| !side_node.is_placeholder()) {
                 current_node = Node::create_node_on_path(path, &current_node, side_node);
@@ -549,11 +560,12 @@ mod test {
 
     #[test]
     fn test_load_returns_a_valid_tree() {
-        // Instantiate a new key-value storage backing and populate it using a sparse Merkle tree.
-        // The root of the Merkle tree is the key that maps to the buffer of the root node in the
-        // storage. When loading a Merkle tree from storage, we need a reference to the storage
-        // object, as well as the root that allows us to look up the buffer of the root node. We
-        // will later use this storage backing and root to load a Merkle tree.
+        // Instantiate a new key-value storage backing and populate it using a sparse
+        // Merkle tree. The root of the Merkle tree is the key that maps to the buffer
+        // of the root node in the storage. When loading a Merkle tree from storage, we
+        // need a reference to the storage object, as well as the root that allows us to
+        // look up the buffer of the root node. We will later use this storage backing
+        // and root to load a Merkle tree.
         let (mut storage_to_load, root_to_load) = {
             let mut storage = StorageMap::<Bytes32, Buffer>::new();
             let mut tree = MerkleTree::<StorageError>::new(&mut storage);
@@ -566,8 +578,9 @@ mod test {
             (storage, root)
         };
 
-        // Generate an expected root for this test by using both the set of `update` data used when
-        // generating the loadable storage above and an additional set of `update` data.
+        // Generate an expected root for this test by using both the set of `update`
+        // data used when generating the loadable storage above and an additional set of
+        // `update` data.
         let expected_root = {
             let mut storage = StorageMap::<Bytes32, Buffer>::new();
             let mut tree = MerkleTree::<StorageError>::new(&mut storage);
@@ -588,10 +601,10 @@ mod test {
             // Create a Merkle tree by loading the generated storage and root.
             let mut tree =
                 MerkleTree::<StorageError>::load(&mut storage_to_load, &root_to_load).unwrap();
-            // Build up the loaded tree using the additional set of `update` data so its root
-            // matches the expected root. This verifies that the loaded tree has successfully
-            // wrapped the given storage backing and assumed the correct state so that future
-            // updates can be made seamlessly.
+            // Build up the loaded tree using the additional set of `update` data so its
+            // root matches the expected root. This verifies that the loaded tree has
+            // successfully wrapped the given storage backing and assumed the correct state
+            // so that future updates can be made seamlessly.
             tree.update(&sum(b"\x00\x00\x00\x05"), b"DATA").unwrap();
             tree.update(&sum(b"\x00\x00\x00\x06"), b"DATA").unwrap();
             tree.update(&sum(b"\x00\x00\x00\x07"), b"DATA").unwrap();

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -23,7 +23,6 @@ const RIGHT: u8 = 1;
 /// `04 - 05`: Prefix (1 byte, 0x01),
 /// `05 - 37`: Left child key (32 bytes),
 /// `37 - 69`: Right child key (32 bytes)
-///
 const BUFFER_SIZE: usize =
     size_of::<Bytes4>() + size_of::<Bytes1>() + size_of::<Bytes32>() + size_of::<Bytes32>();
 pub type Buffer = [u8; BUFFER_SIZE];
@@ -60,9 +59,10 @@ impl Node {
 
     pub fn create_node_on_path(path: &Bytes32, path_node: &Node, side_node: &Node) -> Self {
         if path_node.is_leaf() && side_node.is_leaf() {
-            // When joining two leaves, the joined node is found where the paths of the two leaves
-            // diverge. The joined node may be a direct parent of the leaves or an ancestor multiple
-            // generations above the leaves.
+            // When joining two leaves, the joined node is found where the paths
+            // of the two leaves diverge. The joined node may be a direct parent
+            // of the leaves or an ancestor multiple generations above the
+            // leaves.
             // N.B.: A leaf can be a placeholder.
             let parent_depth = path_node.common_path_length(side_node);
             let parent_height = (Node::max_height() - parent_depth) as u32;
@@ -73,9 +73,9 @@ impl Node {
             };
             parent_node
         } else {
-            // When joining two nodes, or a node and a leaf, the joined node is the direct parent
-            // of the node with the greater height and an ancestor of the node with the lesser
-            // height.
+            // When joining two nodes, or a node and a leaf, the joined node is
+            // the direct parent of the node with the greater height and an
+            // ancestor of the node with the lesser height.
             // N.B.: A leaf can be a placeholder.
             let parent_height = std::cmp::max(path_node.height(), side_node.height()) + 1;
             let parent_depth = Node::max_height() - parent_height as usize;
@@ -103,9 +103,10 @@ impl Node {
         debug_assert!(self.is_leaf());
         debug_assert!(other.is_leaf());
 
-        // If either of the nodes are placeholders, the common path length is defined to be 0. This
-        // is needed to prevent a 0 bit in the placeholder's key from producing an erroneous match
-        // with a 0 bit in the leaf's key.
+        // If either of the nodes are placeholders, the common path length is
+        // defined to be 0. This is needed to prevent a 0 bit in the
+        // placeholder's key from producing an erroneous match with a 0 bit in
+        // the leaf's key.
         if self.is_placeholder() || other.is_placeholder() {
             0
         } else {

--- a/test-helpers/src/binary/verify.rs
+++ b/test-helpers/src/binary/verify.rs
@@ -82,8 +82,9 @@ mod test {
 
     #[test]
     fn verify_returns_false_when_the_given_proof_set_does_not_match_the_given_merkle_root() {
-        // Check the Merkle root of one tree against the computed Merkle root of another tree's
-        // proof set: because the two roots come from different trees, the comparison should fail.
+        // Check the Merkle root of one tree against the computed Merkle root of
+        // another tree's proof set: because the two roots come from different
+        // trees, the comparison should fail.
 
         // Generate the first Merkle tree and get its root
         let mut mt = MerkleTree::new();


### PR DESCRIPTION
Related issues: 
- Closes https://github.com/FuelLabs/fuel-merkle/issues/85

This PR reformats block comments across all files in the repo to not exceed a line length of 80 characters. Where a comment exceeds 80 characters, a line break is inserted before the hanging word such that the line length is 80 characters or less. In cases where this rule cannot be applied, the line length is left unchanged (i.e., URLs, diagrams, etc.).

Originally, I investigated using a `rustfmt.toml` file to specify line length, and apply formatting automatically with `cargo fmt`. However, this imposes the following challenges:
- Formatting line length requires settings `comment_width` and `max_width`; both settings are only available in the nightly toolchain
- Automatic formatting gave seemingly inconsistent behaviour when dealing with existing line breaks; sometimes a line break would be respected when it should be removed to reformat the line to the correct length; sometimes a line break would be removed when it was intended to start a new paragraph

Instead of submitting the `rustfmt.toml` to the repo, I opted to reformat the files using a combination of `cargo fmt` and manual refactoring. Going forward, comments should be manually aligned to fit the 80 character limit. In the future, if and when comment width is added to the stable toolchain, we can revisit adding it to the `rustfmt.toml` file.