### PR TITLE
Debt: Refactor Merkle tree error propagation and handling

### DIFF
--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -8,7 +8,7 @@ use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
-pub enum MerkleTreeError {
+pub enum MerkleTreeError<StorageError> {
     #[cfg_attr(feature = "std", error("proof index {0} is not valid"))]
     InvalidProofIndex(u64),
 
@@ -17,22 +17,25 @@ pub enum MerkleTreeError {
         error("cannot load node with key {0}; the key is not found in storage")
     )]
     LoadError(u64),
+
+    #[error("a storage error was thrown: {0}")]
+    StorageError(#[from] StorageError),
 }
 
 type ProofSet = Vec<Bytes32>;
-type StorageType<StorageError> = dyn Storage<u64, Node, Error = StorageError>;
 
-pub struct MerkleTree<'storage, StorageError> {
-    storage: &'storage mut StorageType<StorageError>,
+pub struct MerkleTree<'storage, StorageType> {
+    storage: &'storage mut StorageType,
     head: Option<Box<Subtree<Node>>>,
     leaves_count: u64,
 }
 
-impl<'storage, StorageError> MerkleTree<'storage, StorageError>
+impl<'storage, StorageType, StorageError> MerkleTree<'storage, StorageType>
 where
-    StorageError: From<MerkleTreeError> + Send + Sync + 'static,
+    StorageType: Storage<u64, Node, Error = StorageError>,
+    StorageError: 'static,
 {
-    pub fn new(storage: &'storage mut StorageType<StorageError>) -> Self {
+    pub fn new(storage: &'storage mut StorageType) -> Self {
         Self {
             storage,
             head: None,
@@ -41,9 +44,9 @@ where
     }
 
     pub fn load(
-        storage: &'storage mut StorageType<StorageError>,
+        storage: &'storage mut StorageType,
         leaves_count: u64,
-    ) -> Result<Self, StorageError> {
+    ) -> Result<Self, MerkleTreeError<StorageError>> {
         let mut tree = Self {
             storage,
             head: None,
@@ -55,7 +58,7 @@ where
         Ok(tree)
     }
 
-    pub fn root(&mut self) -> Result<Bytes32, StorageError> {
+    pub fn root(&mut self) -> Result<Bytes32, MerkleTreeError<StorageError>> {
         let root_node = self.root_node()?;
         let root = match root_node {
             None => *binary::empty_sum(),
@@ -65,7 +68,7 @@ where
         Ok(root)
     }
 
-    pub fn prove(&mut self, proof_index: u64) -> Result<(Bytes32, ProofSet), StorageError> {
+    pub fn prove(&mut self, proof_index: u64) -> Result<(Bytes32, ProofSet), MerkleTreeError<StorageError>> {
         if proof_index + 1 > self.leaves_count {
             return Err(MerkleTreeError::InvalidProofIndex(proof_index).into());
         }
@@ -95,7 +98,7 @@ where
         Ok((root, proof_set))
     }
 
-    pub fn push(&mut self, data: &[u8]) -> Result<(), StorageError> {
+    pub fn push(&mut self, data: &[u8]) -> Result<(), MerkleTreeError<StorageError>> {
         let node = Node::create_leaf(self.leaves_count, data);
         self.storage.insert(&node.key(), &node)?;
         let next = self.head.take();
@@ -112,7 +115,7 @@ where
     // PRIVATE
     //
 
-    fn build(&mut self) -> Result<(), StorageError> {
+    fn build(&mut self) -> Result<(), MerkleTreeError<StorageError>> {
         let keys = (0..self.leaves_count).map(|i| Position::from_leaf_index(i).in_order_index());
         for key in keys {
             let node = self
@@ -185,15 +188,15 @@ where
 mod test {
     use super::{MerkleTree, Storage};
     use crate::binary::{empty_sum, leaf_sum, node_sum, Node};
-    use crate::common::{StorageError, StorageMap};
+    use crate::common::{StorageMapError, StorageMap};
     use fuel_merkle_test_helpers::TEST_DATA;
 
-    type MT<'a> = MerkleTree<'a, StorageError>;
+    // type MT<'a> = MerkleTree<'a, StorageMap>;
 
     #[test]
     fn test_push_builds_internal_tree_structure() {
         let mut storage_map = StorageMap::<u64, Node>::new();
-        let mut tree = MT::new(&mut storage_map);
+        let mut tree = MerkleTree::new(&mut storage_map);
 
         let data = &TEST_DATA[0..7]; // 7 leaves
         for datum in data.iter() {
@@ -259,7 +262,7 @@ mod test {
         let mut storage_map = StorageMap::<u64, Node>::new();
 
         let root_1 = {
-            let mut tree = MT::new(&mut storage_map);
+            let mut tree = MerkleTree::new(&mut storage_map);
             let data = &TEST_DATA[0..LEAVES_COUNT as usize];
             for datum in data.iter() {
                 let _ = tree.push(datum);
@@ -268,7 +271,7 @@ mod test {
         };
 
         let root_2 = {
-            let mut tree = MT::load(&mut storage_map, LEAVES_COUNT).unwrap();
+            let mut tree = MerkleTree::load(&mut storage_map, LEAVES_COUNT).unwrap();
             tree.root().unwrap()
         };
 
@@ -280,7 +283,7 @@ mod test {
         let mut storage_map = StorageMap::<u64, Node>::new();
 
         {
-            let mut tree = MT::new(&mut storage_map);
+            let mut tree = MerkleTree::new(&mut storage_map);
             let data = &TEST_DATA[0..5];
             for datum in data.iter() {
                 let _ = tree.push(datum);
@@ -288,7 +291,7 @@ mod test {
         }
 
         {
-            let tree = MT::load(&mut storage_map, 10);
+            let tree = MerkleTree::load(&mut storage_map, 10);
             assert!(tree.is_err());
         }
     }
@@ -296,7 +299,7 @@ mod test {
     #[test]
     fn root_returns_the_empty_root_for_0_leaves() {
         let mut storage_map = StorageMap::<u64, Node>::new();
-        let mut tree = MT::new(&mut storage_map);
+        let mut tree = MerkleTree::new(&mut storage_map);
 
         let root = tree.root().unwrap();
         assert_eq!(root, empty_sum().clone());
@@ -305,7 +308,7 @@ mod test {
     #[test]
     fn root_returns_the_merkle_root_for_1_leaf() {
         let mut storage_map = StorageMap::<u64, Node>::new();
-        let mut tree = MT::new(&mut storage_map);
+        let mut tree = MerkleTree::new(&mut storage_map);
 
         let data = &TEST_DATA[0..1]; // 1 leaf
         for datum in data.iter() {
@@ -321,7 +324,7 @@ mod test {
     #[test]
     fn root_returns_the_merkle_root_for_7_leaves() {
         let mut storage_map = StorageMap::<u64, Node>::new();
-        let mut tree = MT::new(&mut storage_map);
+        let mut tree = MerkleTree::new(&mut storage_map);
 
         let data = &TEST_DATA[0..7]; // 7 leaves
         for datum in data.iter() {
@@ -365,7 +368,7 @@ mod test {
     #[test]
     fn prove_returns_invalid_proof_index_error_for_0_leaves() {
         let mut storage_map = StorageMap::<u64, Node>::new();
-        let mut tree = MT::new(&mut storage_map);
+        let mut tree = MerkleTree::new(&mut storage_map);
 
         let proof = tree.prove(0);
         assert!(proof.is_err());
@@ -374,7 +377,7 @@ mod test {
     #[test]
     fn prove_returns_invalid_proof_index_error_when_index_is_greater_than_number_of_leaves() {
         let mut storage_map = StorageMap::<u64, Node>::new();
-        let mut tree = MT::new(&mut storage_map);
+        let mut tree = MerkleTree::new(&mut storage_map);
 
         let data = &TEST_DATA[0..5]; // 5 leaves
         for datum in data.iter() {
@@ -388,7 +391,7 @@ mod test {
     #[test]
     fn prove_returns_the_merkle_root_and_proof_set_for_1_leaf() {
         let mut storage_map = StorageMap::<u64, Node>::new();
-        let mut tree = MT::new(&mut storage_map);
+        let mut tree = MerkleTree::new(&mut storage_map);
 
         let data = &TEST_DATA[0..1]; // 1 leaf
         for datum in data.iter() {
@@ -410,7 +413,7 @@ mod test {
     #[test]
     fn prove_returns_the_merkle_root_and_proof_set_for_4_leaves() {
         let mut storage_map = StorageMap::<u64, Node>::new();
-        let mut tree = MT::new(&mut storage_map);
+        let mut tree = MerkleTree::new(&mut storage_map);
 
         let data = &TEST_DATA[0..4]; // 4 leaves
         for datum in data.iter() {
@@ -479,7 +482,7 @@ mod test {
     #[test]
     fn prove_returns_the_merkle_root_and_proof_set_for_5_leaves() {
         let mut storage_map = StorageMap::<u64, Node>::new();
-        let mut tree = MT::new(&mut storage_map);
+        let mut tree = MerkleTree::new(&mut storage_map);
 
         let data = &TEST_DATA[0..5]; // 5 leaves
         for datum in data.iter() {
@@ -566,7 +569,7 @@ mod test {
     #[test]
     fn prove_returns_the_merkle_root_and_proof_set_for_7_leaves() {
         let mut storage_map = StorageMap::<u64, Node>::new();
-        let mut tree = MT::new(&mut storage_map);
+        let mut tree = MerkleTree::new(&mut storage_map);
 
         let data = &TEST_DATA[0..7]; // 7 leaves
         for datum in data.iter() {

--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -18,8 +18,13 @@ pub enum MerkleTreeError<StorageError> {
     )]
     LoadError(u64),
 
-    #[error("a storage error was thrown: {0}")]
-    StorageError(#[from] StorageError),
+    StorageError(StorageError),
+}
+
+impl<StorageError> From<StorageError> for MerkleTreeError<StorageError> {
+    fn from(err: StorageError) -> MerkleTreeError<StorageError> {
+        MerkleTreeError::StorageError(err)
+    }
 }
 
 type ProofSet = Vec<Bytes32>;
@@ -191,7 +196,7 @@ where
 mod test {
     use super::{MerkleTree, Storage};
     use crate::binary::{empty_sum, leaf_sum, node_sum, Node};
-    use crate::common::{StorageMap, StorageMapError};
+    use crate::common::StorageMap;
     use fuel_merkle_test_helpers::TEST_DATA;
 
     // type MT<'a> = MerkleTree<'a, StorageMap>;

--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -68,7 +68,10 @@ where
         Ok(root)
     }
 
-    pub fn prove(&mut self, proof_index: u64) -> Result<(Bytes32, ProofSet), MerkleTreeError<StorageError>> {
+    pub fn prove(
+        &mut self,
+        proof_index: u64,
+    ) -> Result<(Bytes32, ProofSet), MerkleTreeError<StorageError>> {
         if proof_index + 1 > self.leaves_count {
             return Err(MerkleTreeError::InvalidProofIndex(proof_index).into());
         }
@@ -188,7 +191,7 @@ where
 mod test {
     use super::{MerkleTree, Storage};
     use crate::binary::{empty_sum, leaf_sum, node_sum, Node};
-    use crate::common::{StorageMapError, StorageMap};
+    use crate::common::{StorageMap, StorageMapError};
     use fuel_merkle_test_helpers::TEST_DATA;
 
     // type MT<'a> = MerkleTree<'a, StorageMap>;

--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -200,8 +200,6 @@ mod test {
     use crate::common::StorageMap;
     use fuel_merkle_test_helpers::TEST_DATA;
 
-    // type MT<'a> = MerkleTree<'a, StorageMap>;
-
     #[test]
     fn test_push_builds_internal_tree_structure() {
         let mut storage_map = StorageMap::<u64, Node>::new();

--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -18,6 +18,7 @@ pub enum MerkleTreeError<StorageError> {
     )]
     LoadError(u64),
 
+    #[cfg_attr(feature = "std", error("a storage error was thrown: {0}"))]
     StorageError(StorageError),
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -15,7 +15,7 @@ pub use position::Position;
 pub use subtree::Subtree;
 
 #[cfg(feature = "std")]
-pub use storage_map::{StorageMapError, StorageMap};
+pub use storage_map::{StorageMap, StorageMapError};
 
 pub(crate) use position_path::PositionPath;
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -15,7 +15,7 @@ pub use position::Position;
 pub use subtree::Subtree;
 
 #[cfg(feature = "std")]
-pub use storage_map::{StorageError, StorageMap};
+pub use storage_map::{StorageMapError, StorageMap};
 
 pub(crate) use position_path::PositionPath;
 

--- a/src/common/msb.rs
+++ b/src/common/msb.rs
@@ -47,7 +47,7 @@ impl<const N: usize> Msb for [u8; N] {
 #[cfg(test)]
 mod test {
     use crate::common::{Bytes1, Bytes2, Bytes4, Bytes8, Msb};
-    use std::mem::size_of;
+    use core::mem::size_of;
 
     #[test]
     fn test_msb_for_bytes_1() {

--- a/src/common/path_iterator.rs
+++ b/src/common/path_iterator.rs
@@ -186,6 +186,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::common::{AsPathIterator, Bytes8, Node, ParentNode};
+    use alloc::vec::Vec;
 
     #[derive(Debug, Clone, PartialEq)]
     struct TestNode {

--- a/src/common/position_path.rs
+++ b/src/common/position_path.rs
@@ -105,6 +105,7 @@ impl Iterator for PositionPathIter {
 #[cfg(test)]
 mod test {
     use crate::common::Position;
+    use alloc::vec::Vec;
 
     #[test]
     fn test_path_set_returns_path_and_side_nodes_for_4_leaves() {

--- a/src/common/storage_map.rs
+++ b/src/common/storage_map.rs
@@ -1,5 +1,3 @@
-use crate::{binary, sparse, sum};
-
 use fuel_storage::Storage;
 use thiserror::Error;
 
@@ -7,15 +5,8 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Error)]
-pub enum StorageError {
-    #[error("A binary merkle tree error was thrown: {0}")]
-    BinaryMerkleTree(#[from] binary::MerkleTreeError),
-
-    #[error("A sparse merkle tree error was thrown: {0}")]
-    SparseMerkleTree(#[from] sparse::MerkleTreeError),
-
-    #[error("A sum merkle tree error was thrown: {0}")]
-    SumMerkleTree(#[from] sum::MerkleTreeError),
+pub enum StorageMapError {
+    // Empty - StorageMap does not produce any errors
 }
 
 #[derive(Debug)]
@@ -36,7 +27,7 @@ where
     Key: Eq + std::hash::Hash + Clone,
     Value: Clone,
 {
-    type Error = StorageError;
+    type Error = StorageMapError;
 
     fn insert(&mut self, key: &Key, value: &Value) -> Result<Option<Value>, Self::Error> {
         self.map.insert(key.clone(), value.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg_attr(test, macro_use)]
 extern crate alloc;
 
 pub mod binary;

--- a/src/sparse/merkle_tree.rs
+++ b/src/sparse/merkle_tree.rs
@@ -16,8 +16,13 @@ pub enum MerkleTreeError<StorageError> {
     )]
     LoadError(String),
 
-    #[error("a storage error was thrown: {0}")]
-    StorageError(#[from] StorageError),
+    StorageError(StorageError),
+}
+
+impl<StorageError> From<StorageError> for MerkleTreeError<StorageError> {
+    fn from(err: StorageError) -> MerkleTreeError<StorageError> {
+        MerkleTreeError::StorageError(err)
+    }
 }
 
 // type StorageType<StorageError> = dyn Storage<Bytes32, Buffer, Error = StorageError>;

--- a/src/sparse/merkle_tree.rs
+++ b/src/sparse/merkle_tree.rs
@@ -54,7 +54,11 @@ where
         Ok(tree)
     }
 
-    pub fn update(&'a mut self, key: &Bytes32, data: &[u8]) -> Result<(), MerkleTreeError<StorageError>> {
+    pub fn update(
+        &'a mut self,
+        key: &Bytes32,
+        data: &[u8],
+    ) -> Result<(), MerkleTreeError<StorageError>> {
         if data.is_empty() {
             // If the data is empty, this signifies a delete operation for the
             // given key.
@@ -254,7 +258,7 @@ where
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod test {
-    use crate::common::{Bytes32, StorageMapError, StorageMap};
+    use crate::common::{Bytes32, StorageMap, StorageMapError};
     use crate::sparse::hash::sum;
     use crate::sparse::{Buffer, MerkleTree};
     use hex;
@@ -610,8 +614,7 @@ mod test {
 
         let root = {
             // Create a Merkle tree by loading the generated storage and root.
-            let mut tree =
-                MerkleTree::load(&mut storage_to_load, &root_to_load).unwrap();
+            let mut tree = MerkleTree::load(&mut storage_to_load, &root_to_load).unwrap();
             // Build up the loaded tree using the additional set of `update` data so its
             // root matches the expected root. This verifies that the loaded tree has
             // successfully wrapped the given storage backing and assumed the correct state

--- a/src/sparse/merkle_tree.rs
+++ b/src/sparse/merkle_tree.rs
@@ -119,8 +119,8 @@ where
 
     fn path_set(&'a self, leaf_node: Node) -> (Vec<Node>, Vec<Node>) {
         let root_node = self.root_node().clone();
-        let root_storage_node = StorageNode::<StorageError>::new(self.storage, root_node);
-        let leaf_storage_node = StorageNode::<StorageError>::new(self.storage, leaf_node);
+        let root_storage_node = StorageNode::new(self.storage, root_node);
+        let leaf_storage_node = StorageNode::new(self.storage, leaf_node);
         let (mut path_nodes, mut side_nodes): (Vec<Node>, Vec<Node>) = root_storage_node
             .as_path_iter(&leaf_storage_node)
             .map(|(node, side_node)| (node.into_node(), side_node.into_node()))

--- a/src/sparse/merkle_tree.rs
+++ b/src/sparse/merkle_tree.rs
@@ -16,6 +16,7 @@ pub enum MerkleTreeError<StorageError> {
     )]
     LoadError(String),
 
+    #[cfg_attr(feature = "std", error("a storage error was thrown: {0}"))]
     StorageError(StorageError),
 }
 

--- a/src/sparse/merkle_tree.rs
+++ b/src/sparse/merkle_tree.rs
@@ -26,8 +26,6 @@ impl<StorageError> From<StorageError> for MerkleTreeError<StorageError> {
     }
 }
 
-// type StorageType<StorageError> = dyn Storage<Bytes32, Buffer, Error = StorageError>;
-
 pub struct MerkleTree<'storage, StorageType> {
     root_node: Node,
     storage: &'storage mut StorageType,

--- a/src/sparse/merkle_tree.rs
+++ b/src/sparse/merkle_tree.rs
@@ -264,7 +264,7 @@ where
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod test {
-    use crate::common::{Bytes32, StorageMap, StorageMapError};
+    use crate::common::{Bytes32, StorageMap};
     use crate::sparse::hash::sum;
     use crate::sparse::{Buffer, MerkleTree};
     use hex;

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -641,6 +641,7 @@ mod test_node {
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod test_storage_node {
     use crate::common::{Bytes32, StorageMap, StorageMapError};

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -354,20 +354,30 @@ impl fmt::Debug for Node {
     }
 }
 
-type NodeStorage<'storage, StorageError> =
-    dyn 'storage + Storage<Bytes32, Buffer, Error = StorageError>;
-
-#[derive(Clone)]
-pub(crate) struct StorageNode<'storage, StorageError> {
-    storage: &'storage NodeStorage<'storage, StorageError>,
+pub(crate) struct StorageNode<'storage, StorageType> {
+    storage: &'storage StorageType,
     node: Node,
 }
 
-impl<'a, 'storage, StorageError> StorageNode<'storage, StorageError>
+impl<'storage, StorageType, StorageError> Clone for StorageNode<'storage, StorageType>
 where
+    StorageType: Storage<Bytes32, Buffer, Error = StorageError>,
     StorageError: fmt::Debug + Clone,
 {
-    pub fn new(storage: &'storage NodeStorage<'storage, StorageError>, node: Node) -> Self {
+    fn clone(&self) -> Self {
+        Self {
+            storage: self.storage,
+            node: self.node.clone(),
+        }
+    }
+}
+
+impl<'storage, StorageType, StorageError> StorageNode<'storage, StorageType>
+where
+    StorageType: Storage<Bytes32, Buffer, Error = StorageError>,
+    StorageError: fmt::Debug + Clone,
+{
+    pub fn new(storage: &'storage StorageType, node: Node) -> Self {
         Self { node, storage }
     }
 
@@ -422,8 +432,9 @@ where
     }
 }
 
-impl<'storage, StorageError> crate::common::Node for StorageNode<'storage, StorageError>
+impl<'storage, StorageType, StorageError> crate::common::Node for StorageNode<'storage, StorageType>
 where
+    StorageType: Storage<Bytes32, Buffer, Error = StorageError>,
     StorageError: fmt::Debug + Clone,
 {
     type Key = Bytes32;
@@ -441,8 +452,10 @@ where
     }
 }
 
-impl<'storage, StorageError> crate::common::ParentNode for StorageNode<'storage, StorageError>
+impl<'storage, StorageType, StorageError> crate::common::ParentNode
+    for StorageNode<'storage, StorageType>
 where
+    StorageType: Storage<Bytes32, Buffer, Error = StorageError>,
     StorageError: fmt::Debug + Clone,
 {
     fn left_child(&self) -> Self {
@@ -454,8 +467,9 @@ where
     }
 }
 
-impl<'storage, StorageError> fmt::Debug for StorageNode<'storage, StorageError>
+impl<'storage, StorageType, StorageError> fmt::Debug for StorageNode<'storage, StorageType>
 where
+    StorageType: Storage<Bytes32, Buffer, Error = StorageError>,
     StorageError: fmt::Debug + Clone,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -644,7 +658,7 @@ mod test_node {
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod test_storage_node {
-    use crate::common::{Bytes32, StorageMap, StorageMapError};
+    use crate::common::{Bytes32, StorageMap};
     use crate::sparse::hash::sum;
     use crate::sparse::node::Buffer;
     use crate::sparse::{Node, StorageNode};
@@ -663,7 +677,7 @@ mod test_storage_node {
         let node_0 = Node::create_node(&leaf_0, &leaf_1, 1);
         let _ = s.insert(&node_0.hash(), node_0.as_buffer());
 
-        let storage_node = StorageNode::<StorageMapError>::new(&mut s, node_0);
+        let storage_node = StorageNode::new(&mut s, node_0);
         let child = storage_node.left_child().unwrap();
 
         assert_eq!(child.hash(), leaf_0.hash());
@@ -682,7 +696,7 @@ mod test_storage_node {
         let node_0 = Node::create_node(&leaf_0, &leaf_1, 1);
         let _ = s.insert(&node_0.hash(), node_0.as_buffer());
 
-        let storage_node = StorageNode::<StorageMapError>::new(&mut s, node_0);
+        let storage_node = StorageNode::new(&mut s, node_0);
         let child = storage_node.right_child().unwrap();
 
         assert_eq!(child.hash(), leaf_1.hash());
@@ -698,7 +712,7 @@ mod test_storage_node {
         let node_0 = Node::create_node(&Node::create_placeholder(), &leaf, 1);
         let _ = s.insert(&node_0.hash(), node_0.as_buffer());
 
-        let storage_node = StorageNode::<StorageMapError>::new(&mut s, node_0);
+        let storage_node = StorageNode::new(&mut s, node_0);
         let child = storage_node.left_child().unwrap();
 
         assert!(child.node.is_placeholder());
@@ -714,7 +728,7 @@ mod test_storage_node {
         let node_0 = Node::create_node(&leaf, &Node::create_placeholder(), 1);
         let _ = s.insert(&node_0.hash(), node_0.as_buffer());
 
-        let storage_node = StorageNode::<StorageMapError>::new(&mut s, node_0);
+        let storage_node = StorageNode::new(&mut s, node_0);
         let child = storage_node.right_child().unwrap();
 
         assert!(child.node.is_placeholder());

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -643,7 +643,7 @@ mod test_node {
 
 #[cfg(test)]
 mod test_storage_node {
-    use crate::common::{Bytes32, StorageError, StorageMap};
+    use crate::common::{Bytes32, StorageMapError, StorageMap};
     use crate::sparse::hash::sum;
     use crate::sparse::node::Buffer;
     use crate::sparse::{Node, StorageNode};
@@ -662,7 +662,7 @@ mod test_storage_node {
         let node_0 = Node::create_node(&leaf_0, &leaf_1, 1);
         let _ = s.insert(&node_0.hash(), node_0.as_buffer());
 
-        let storage_node = StorageNode::<StorageError>::new(&mut s, node_0);
+        let storage_node = StorageNode::<StorageMapError>::new(&mut s, node_0);
         let child = storage_node.left_child().unwrap();
 
         assert_eq!(child.hash(), leaf_0.hash());
@@ -681,7 +681,7 @@ mod test_storage_node {
         let node_0 = Node::create_node(&leaf_0, &leaf_1, 1);
         let _ = s.insert(&node_0.hash(), node_0.as_buffer());
 
-        let storage_node = StorageNode::<StorageError>::new(&mut s, node_0);
+        let storage_node = StorageNode::<StorageMapError>::new(&mut s, node_0);
         let child = storage_node.right_child().unwrap();
 
         assert_eq!(child.hash(), leaf_1.hash());
@@ -697,7 +697,7 @@ mod test_storage_node {
         let node_0 = Node::create_node(&Node::create_placeholder(), &leaf, 1);
         let _ = s.insert(&node_0.hash(), node_0.as_buffer());
 
-        let storage_node = StorageNode::<StorageError>::new(&mut s, node_0);
+        let storage_node = StorageNode::<StorageMapError>::new(&mut s, node_0);
         let child = storage_node.left_child().unwrap();
 
         assert!(child.node.is_placeholder());
@@ -713,7 +713,7 @@ mod test_storage_node {
         let node_0 = Node::create_node(&leaf, &Node::create_placeholder(), 1);
         let _ = s.insert(&node_0.hash(), node_0.as_buffer());
 
-        let storage_node = StorageNode::<StorageError>::new(&mut s, node_0);
+        let storage_node = StorageNode::<StorageMapError>::new(&mut s, node_0);
         let child = storage_node.right_child().unwrap();
 
         assert!(child.node.is_placeholder());

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -643,7 +643,7 @@ mod test_node {
 
 #[cfg(test)]
 mod test_storage_node {
-    use crate::common::{Bytes32, StorageMapError, StorageMap};
+    use crate::common::{Bytes32, StorageMap, StorageMapError};
     use crate::sparse::hash::sum;
     use crate::sparse::node::Buffer;
     use crate::sparse::{Node, StorageNode};

--- a/src/sum/merkle_tree.rs
+++ b/src/sum/merkle_tree.rs
@@ -118,10 +118,10 @@ where
 mod test {
     use fuel_merkle_test_helpers::TEST_DATA;
 
-    use crate::common::{Bytes32, StorageError, StorageMap};
+    use crate::common::{Bytes32, StorageMapError, StorageMap};
     use crate::sum::{empty_sum, leaf_sum, node_sum, MerkleTree, Node};
 
-    type MT<'storage> = MerkleTree<'storage, StorageError>;
+    type MT<'storage> = MerkleTree<'storage, StorageMapError>;
     const FEE: u64 = 100;
 
     #[test]

--- a/src/sum/merkle_tree.rs
+++ b/src/sum/merkle_tree.rs
@@ -118,7 +118,7 @@ where
 mod test {
     use fuel_merkle_test_helpers::TEST_DATA;
 
-    use crate::common::{Bytes32, StorageMapError, StorageMap};
+    use crate::common::{Bytes32, StorageMap, StorageMapError};
     use crate::sum::{empty_sum, leaf_sum, node_sum, MerkleTree, Node};
 
     type MT<'storage> = MerkleTree<'storage, StorageMapError>;

--- a/tests-data/tests-data.rs
+++ b/tests-data/tests-data.rs
@@ -1,6 +1,6 @@
 use std::{fs::File, path::Path};
 
-use fuel_merkle::common::{Bytes32, StorageMapError, StorageMap};
+use fuel_merkle::common::{Bytes32, StorageMap, StorageMapError};
 use fuel_merkle::sparse::MerkleTree as SparseMerkleTree;
 use serde::Deserialize;
 use std::convert::TryInto;
@@ -22,7 +22,6 @@ const BUFFER_SIZE: usize = 69;
 type Buffer = [u8; BUFFER_SIZE];
 type Storage = StorageMap<Bytes32, Buffer>;
 type MerkleTree<'a> = SparseMerkleTree<'a, Storage>;
-
 
 // Supported actions:
 const ACTION_UPDATE: &str = "update";
@@ -78,10 +77,7 @@ enum Action {
 }
 
 impl Step {
-    pub fn execute(
-        self,
-        tree: &mut MerkleTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn execute(self, tree: &mut MerkleTree) -> Result<(), Box<dyn std::error::Error>> {
         match self.action_type()? {
             Action::Update(encoded_key, encoded_data) => {
                 let key_bytes = encoded_key.to_bytes()?;

--- a/tests-data/tests-data.rs
+++ b/tests-data/tests-data.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, path::Path};
 
-use fuel_merkle::common::{Bytes32, StorageError, StorageMap};
-use fuel_merkle::sparse::MerkleTree;
+use fuel_merkle::common::{Bytes32, StorageMapError, StorageMap};
+use fuel_merkle::sparse::MerkleTree as SparseMerkleTree;
 use serde::Deserialize;
 use std::convert::TryInto;
 use std::fmt::{Display, Formatter};
@@ -19,7 +19,10 @@ pub enum TestError {
 }
 
 const BUFFER_SIZE: usize = 69;
-pub type Buffer = [u8; BUFFER_SIZE];
+type Buffer = [u8; BUFFER_SIZE];
+type Storage = StorageMap<Bytes32, Buffer>;
+type MerkleTree<'a> = SparseMerkleTree<'a, Storage>;
+
 
 // Supported actions:
 const ACTION_UPDATE: &str = "update";
@@ -77,7 +80,7 @@ enum Action {
 impl Step {
     pub fn execute(
         self,
-        tree: &mut MerkleTree<StorageError>,
+        tree: &mut MerkleTree,
     ) -> Result<(), Box<dyn std::error::Error>> {
         match self.action_type()? {
             Action::Update(encoded_key, encoded_data) => {
@@ -128,7 +131,7 @@ struct Test {
 impl Test {
     pub fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
         let mut storage = StorageMap::<Bytes32, Buffer>::new();
-        let mut tree = MerkleTree::<StorageError>::new(&mut storage);
+        let mut tree = MerkleTree::new(&mut storage);
 
         for step in self.steps {
             step.execute(&mut tree)?

--- a/tests-data/tests-data.rs
+++ b/tests-data/tests-data.rs
@@ -1,6 +1,6 @@
 use std::{fs::File, path::Path};
 
-use fuel_merkle::common::{Bytes32, StorageMap, StorageMapError};
+use fuel_merkle::common::{Bytes32, StorageMap};
 use fuel_merkle::sparse::MerkleTree as SparseMerkleTree;
 use serde::Deserialize;
 use std::convert::TryInto;


### PR DESCRIPTION
Related issues:
- Closes #89 

Currently, binary and sparse Merkle tree functions are defined to throw a `storage_map::StorageError` on error; errors internal to the Merkle tree arising from an invalid state or operation (`MerkleTreeError`) are cast to `StorageError` to accommodate this interface. 

One issue with this approach is that the Merkle tree interfaces are coupled to the `storage_map::StorageError` type. A superior approach is to define Merkle tree types with a generic `StorageType`, where a `StorageType` is an implementor of the `fuel_storage::Storage` trait and encapsulates a storage-specific error. This allows the Merkle tree interfaces to decouple from the `storage_map::StorageError` and to instead define function error types generically over the `StorageType`'s error. By definition, storage types must supply a related error.

We can maintain and expand on existing behaviour by defining in-memory Merkle trees with the `StorageMap`:
```rust
type Storage = StorageMap<Bytes32, Buffer>;
let storage = Storage::new();
let tree = sparse::MerkleTree::new(&storage);
```
This has the additional ergonomic benefit that tree types can now infer the generic `StorageType` based on the storage argument passed to the constructor. Contrast this to the existing requirement where trees must always specify an error type: `sparse::MerkleTree<ErrorType>::new(&storage)`.

To handle internal `MerkleTreeError` errors, the directionality of casting is now reversed: instead of translating a `MerkleTreeError` to a concrete `storage_map::StorageError`, the `MerkleTreeError` type is now itself generic on the parameterized `StorageType::Error`. This way, Merkle tree interfaces can return Merkle trees can return either an internal error, i.e. `MerkleTreeError<StorageError>`, or a `StorageError` directly when no internal error can be raised. 