### PR TITLE
Feat: Enable use of StorageMap without `std` feature 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ description = "Fuel Merkle tree libraries."
 [dependencies]
 digest = { version = "0.10", default-features = false }
 fuel-storage = "0.2"
+hashbrown = "0.12"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 sha2 = { version = "0.10", default-features = false }
 thiserror = { version = "1.0", optional = true }

--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -192,7 +192,6 @@ where
     }
 }
 
-#[cfg(feature = "std")]
 #[cfg(test)]
 mod test {
     use super::{MerkleTree, Storage};

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,19 +3,15 @@ mod node;
 mod path_iterator;
 mod position;
 mod position_path;
-mod subtree;
-
-#[cfg(feature = "std")]
 mod storage_map;
+mod subtree;
 
 pub use msb::Msb;
 pub use node::{Node, ParentNode};
 pub use path_iterator::AsPathIterator;
 pub use position::Position;
-pub use subtree::Subtree;
-
-#[cfg(feature = "std")]
 pub use storage_map::{StorageMap, StorageMapError};
+pub use subtree::Subtree;
 
 pub(crate) use position_path::PositionPath;
 

--- a/src/common/storage_map.rs
+++ b/src/common/storage_map.rs
@@ -1,10 +1,10 @@
 use fuel_storage::Storage;
-use thiserror::Error;
 
-use std::borrow::Cow;
-use std::collections::HashMap;
+use alloc::borrow::Cow;
+use hashbrown::HashMap;
 
-#[derive(Debug, Clone, Error)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
 pub enum StorageMapError {
     // Empty - StorageMap does not produce any errors
 }
@@ -24,7 +24,7 @@ impl<Key, Value> StorageMap<Key, Value> {
 
 impl<Key, Value> Storage<Key, Value> for StorageMap<Key, Value>
 where
-    Key: Eq + std::hash::Hash + Clone,
+    Key: Eq + core::hash::Hash + Clone,
     Value: Clone,
 {
     type Error = StorageMapError;
@@ -55,16 +55,9 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::fmt::Formatter;
 
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
     struct TestKey(u32);
-
-    impl std::fmt::Display for TestKey {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self.0)
-        }
-    }
 
     #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     struct TestValue(u32);

--- a/src/sparse/merkle_tree.rs
+++ b/src/sparse/merkle_tree.rs
@@ -259,7 +259,6 @@ where
     }
 }
 
-#[cfg(feature = "std")]
 #[cfg(test)]
 mod test {
     use crate::common::{Bytes32, StorageMap};

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -655,7 +655,6 @@ mod test_node {
     }
 }
 
-#[cfg(feature = "std")]
 #[cfg(test)]
 mod test_storage_node {
     use crate::common::{Bytes32, StorageMap};

--- a/src/sum/merkle_tree.rs
+++ b/src/sum/merkle_tree.rs
@@ -113,7 +113,6 @@ where
     }
 }
 
-#[cfg(feature = "std")]
 #[cfg(test)]
 mod test {
     use fuel_merkle_test_helpers::TEST_DATA;


### PR DESCRIPTION
Related issues:
- Closes #91 

This PR replaces the `StorageMap`'s usage of the standard `HashMap` with a drop-in replacement from `hashbrown`. `hashbrown::HashMap` provides identical functionality without the use of `std`. 

This enables consumer libs to use `fuel_merkle::StorageMap` in a non-`std` context. Client code that uses Merkle trees can now use the `StorageMap` as the default in-memory storage backing without implementing their own non-`std` storage.

This also enables the unit tests within `fuel_merkle` to execute without the `std` feature flag. This allows us to verify behaviour in both the `std` and non-`std` environments. Currently, CI runs tests with `std`; in the future, CI will additionally run tests without the `std` flag. 

This PR is currently built off of the work in #94 and uses that branch as the base - once that PR is in master, I will change the base branch of this PR back to master. 