### PR TITLE
Feat: Use infallible error for `StorageMap` error type

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -10,7 +10,7 @@ pub use msb::Msb;
 pub use node::{Node, ParentNode};
 pub use path_iterator::AsPathIterator;
 pub use position::Position;
-pub use storage_map::{StorageMap, StorageMapError};
+pub use storage_map::StorageMap;
 pub use subtree::Subtree;
 
 pub(crate) use position_path::PositionPath;

--- a/src/common/storage_map.rs
+++ b/src/common/storage_map.rs
@@ -3,12 +3,6 @@ use fuel_storage::Storage;
 use alloc::borrow::Cow;
 use hashbrown::HashMap;
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "std", derive(thiserror::Error))]
-pub enum StorageMapError {
-    // Empty - StorageMap does not produce any errors
-}
-
 #[derive(Debug)]
 pub struct StorageMap<Key, Value> {
     map: HashMap<Key, Value>,
@@ -27,7 +21,7 @@ where
     Key: Eq + core::hash::Hash + Clone,
     Value: Clone,
 {
-    type Error = StorageMapError;
+    type Error = core::convert::Infallible;
 
     fn insert(&mut self, key: &Key, value: &Value) -> Result<Option<Value>, Self::Error> {
         self.map.insert(key.clone(), value.clone());

--- a/src/sum/merkle_tree.rs
+++ b/src/sum/merkle_tree.rs
@@ -117,10 +117,11 @@ where
 mod test {
     use fuel_merkle_test_helpers::TEST_DATA;
 
-    use crate::common::{Bytes32, StorageMap, StorageMapError};
+    use crate::common::{Bytes32, StorageMap};
     use crate::sum::{empty_sum, leaf_sum, node_sum, MerkleTree, Node};
 
-    type MT<'storage> = MerkleTree<'storage, StorageMapError>;
+    type StorageError = core::convert::Infallible;
+    type MT<'storage> = MerkleTree<'storage, StorageError>;
     const FEE: u64 = 100;
 
     #[test]


### PR DESCRIPTION
Related issues:
- Closes #97 

Because the `StorageMap` cannot raise any errors in practice, it is preferable to use an error type that represents this. Currently, the `StorageMapError` type exists as an empty error enum for this purpose. However, the `core::convert::Infallible` type is a core type designed for this purpose and is a drop in replacement with full functionality.   