### PR TITLE
Feat: Infallible in-memory SMT 

### DIFF
--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -1,6 +1,7 @@
+use core::fmt;
+
 use crate::binary::{self, Node};
 use crate::common::{Bytes32, Position, Subtree};
-
 use fuel_storage::Storage;
 
 use alloc::boxed::Box;
@@ -30,18 +31,18 @@ impl<StorageError> From<StorageError> for MerkleTreeError<StorageError> {
 
 type ProofSet = Vec<Bytes32>;
 
-pub struct MerkleTree<'storage, StorageType> {
-    storage: &'storage mut StorageType,
+pub struct MerkleTree<StorageType> {
+    storage: StorageType,
     head: Option<Box<Subtree<Node>>>,
     leaves_count: u64,
 }
 
-impl<'storage, StorageType, StorageError> MerkleTree<'storage, StorageType>
+impl<StorageType, StorageError> MerkleTree<StorageType>
 where
     StorageType: Storage<u64, Node, Error = StorageError>,
-    StorageError: 'static,
+    StorageError: fmt::Debug + Clone + 'static,
 {
-    pub fn new(storage: &'storage mut StorageType) -> Self {
+    pub fn new(storage: StorageType) -> Self {
         Self {
             storage,
             head: None,
@@ -50,7 +51,7 @@ where
     }
 
     pub fn load(
-        storage: &'storage mut StorageType,
+        storage: StorageType,
         leaves_count: u64,
     ) -> Result<Self, MerkleTreeError<StorageError>> {
         let mut tree = Self {

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -1,6 +1,7 @@
 mod hash;
 mod merkle_tree;
 mod node;
+mod in_memory;
 
 pub use merkle_tree::{MerkleTree, MerkleTreeError};
 

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -1,9 +1,9 @@
 mod hash;
-mod in_memory;
 mod merkle_tree;
 mod node;
 
 pub use merkle_tree::{MerkleTree, MerkleTreeError};
+pub mod in_memory;
 
 pub(crate) use hash::zero_sum;
 pub(crate) use node::{Buffer, Node, StorageNode};

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -1,7 +1,7 @@
 mod hash;
+mod in_memory;
 mod merkle_tree;
 mod node;
-mod in_memory;
 
 pub use merkle_tree::{MerkleTree, MerkleTreeError};
 

--- a/src/sparse/in_memory.rs
+++ b/src/sparse/in_memory.rs
@@ -2,62 +2,30 @@ use crate::common::Bytes32;
 use crate::sparse::Buffer;
 use crate::{common, sparse};
 
-use alloc::boxed::Box;
-use core::marker::PhantomPinned;
-use core::pin::Pin;
-use core::ptr::NonNull;
-
 type StorageMap = common::StorageMap<Bytes32, Buffer>;
-type SparseMerkleTree<'a> = sparse::MerkleTree<'a, StorageMap>;
+type SparseMerkleTree = sparse::MerkleTree<StorageMap>;
 
-pub struct MerkleTree<'a> {
-    storage: StorageMap,
-    tree: Option<SparseMerkleTree<'a>>,
-    _marker: PhantomPinned,
+pub struct MerkleTree {
+    tree: SparseMerkleTree,
 }
 
-impl<'a> MerkleTree<'a> {
-    pub fn new() -> Pin<Box<Self>> {
-        let res = Self {
-            storage: StorageMap::new(),
-            tree: None,
-            _marker: PhantomPinned,
-        };
-
-        let mut boxed = Box::pin(res);
-
-        unsafe {
-            let mut storage = NonNull::from(&boxed.storage);
-            boxed.as_mut().get_unchecked_mut().tree = Some(SparseMerkleTree::new(storage.as_mut()));
-        }
-
-        boxed
-    }
-
-    pub fn update(self: Pin<&mut Self>, key: &Bytes32, data: &[u8]) {
-        unsafe {
-            self.get_unchecked_mut()
-                .tree
-                .as_mut()
-                .unwrap_unchecked()
-                .update(key, data)
-                .unwrap_unchecked();
+impl MerkleTree {
+    pub fn new() -> Self {
+        Self {
+            tree: SparseMerkleTree::new(StorageMap::new()),
         }
     }
 
-    pub fn delete(self: Pin<&mut Self>, key: &Bytes32) {
-        unsafe {
-            self.get_unchecked_mut()
-                .tree
-                .as_mut()
-                .unwrap_unchecked()
-                .delete(key)
-                .unwrap_unchecked();
-        }
+    pub fn update(&mut self, key: &Bytes32, data: &[u8]) {
+        let _ = self.tree.update(key, data);
     }
 
-    pub fn root(self: Pin<&Self>) -> Bytes32 {
-        unsafe { self.tree.as_ref().unwrap_unchecked().root() }
+    pub fn delete(&mut self, key: &Bytes32) {
+        let _ = self.tree.delete(key);
+    }
+
+    pub fn root(&self) -> Bytes32 {
+        self.tree.root()
     }
 }
 
@@ -69,7 +37,7 @@ mod test {
     #[test]
     fn test_empty_root() {
         let tree = MerkleTree::new();
-        let root = tree.as_ref().root();
+        let root = tree.root();
         let expected_root = "0000000000000000000000000000000000000000000000000000000000000000";
         assert_eq!(hex::encode(root), expected_root);
     }
@@ -78,9 +46,9 @@ mod test {
     fn test_update_1() {
         let mut tree = MerkleTree::new();
 
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x00"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x00"), b"DATA");
 
-        let root = tree.as_ref().root();
+        let root = tree.root();
         let expected_root = "39f36a7cb4dfb1b46f03d044265df6a491dffc1034121bc1071a34ddce9bb14b";
         assert_eq!(hex::encode(root), expected_root);
     }
@@ -89,10 +57,10 @@ mod test {
     fn test_update_2() {
         let mut tree = MerkleTree::new();
 
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x00"), b"DATA");
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x01"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x00"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x01"), b"DATA");
 
-        let root = tree.as_ref().root();
+        let root = tree.root();
         let expected_root = "8d0ae412ca9ca0afcb3217af8bcd5a673e798bd6fd1dfacad17711e883f494cb";
         assert_eq!(hex::encode(root), expected_root);
     }
@@ -101,11 +69,11 @@ mod test {
     fn test_update_3() {
         let mut tree = MerkleTree::new();
 
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x00"), b"DATA");
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x01"), b"DATA");
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x02"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x00"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x01"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x02"), b"DATA");
 
-        let root = tree.as_ref().root();
+        let root = tree.root();
         let expected_root = "52295e42d8de2505fdc0cc825ff9fead419cbcf540d8b30c7c4b9c9b94c268b7";
         assert_eq!(hex::encode(root), expected_root);
     }
@@ -114,10 +82,10 @@ mod test {
     fn test_update_1_delete_1() {
         let mut tree = MerkleTree::new();
 
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x00"), b"DATA");
-        tree.as_mut().delete(&sum(b"\x00\x00\x00\x00"));
+        tree.update(&sum(b"\x00\x00\x00\x00"), b"DATA");
+        tree.delete(&sum(b"\x00\x00\x00\x00"));
 
-        let root = tree.as_ref().root();
+        let root = tree.root();
         let expected_root = "0000000000000000000000000000000000000000000000000000000000000000";
         assert_eq!(hex::encode(root), expected_root);
     }
@@ -126,11 +94,11 @@ mod test {
     fn test_update_2_delete_1() {
         let mut tree = MerkleTree::new();
 
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x00"), b"DATA");
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x01"), b"DATA");
-        tree.as_mut().delete(&sum(b"\x00\x00\x00\x01"));
+        tree.update(&sum(b"\x00\x00\x00\x00"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x01"), b"DATA");
+        tree.delete(&sum(b"\x00\x00\x00\x01"));
 
-        let root = tree.as_ref().root();
+        let root = tree.root();
         let expected_root = "39f36a7cb4dfb1b46f03d044265df6a491dffc1034121bc1071a34ddce9bb14b";
         assert_eq!(hex::encode(root), expected_root);
     }

--- a/src/sparse/in_memory.rs
+++ b/src/sparse/in_memory.rs
@@ -1,0 +1,66 @@
+use crate::sparse::{Buffer};
+use crate::{common, sparse};
+use crate::common::{Bytes32};
+use std::pin::Pin;
+use std::marker::PhantomPinned;
+use std::ptr::NonNull;
+
+type StorageMap = common::StorageMap<Bytes32, Buffer>;
+type SparseMerkleTree<'a> = sparse::MerkleTree<'a, StorageMap>;
+
+pub struct MerkleTree<'a> {
+    storage: StorageMap,
+    tree: *mut SparseMerkleTree<'a>
+}
+
+impl<'a> MerkleTree<'a> {
+    pub fn new() -> Pin<Box<Self>> {
+        let res = Self {
+            storage: StorageMap::new(),
+            tree: std::ptr::null_mut()
+        };
+
+        let mut boxed = Box::pin(res);
+
+        unsafe {
+            let mut storage = NonNull::from(&boxed.storage);
+            let mut tree = Box::pin(SparseMerkleTree::new(storage.as_mut()));
+            boxed.tree = tree.as_mut().get_unchecked_mut();
+        }
+
+        boxed
+    }
+
+    pub fn update(
+        &mut self,
+        key: &Bytes32,
+        data: &[u8],
+    ) {
+        unsafe {
+            self.tree.as_mut().unwrap_unchecked().update(key, data).unwrap_unchecked();
+        }
+    }
+
+    pub fn root(&self) -> Bytes32 {
+        unsafe {
+            self.tree.as_ref().unwrap_unchecked().root()
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use sparse::hash::sum;
+
+    #[test]
+    fn test_update_1() {
+        let mut tree = MerkleTree::new();
+
+        tree.update(&sum(b"\x00\x00\x00\x00"), b"DATA");
+
+        let root = tree.root();
+        let expected_root = "39f36a7cb4dfb1b46f03d044265df6a491dffc1034121bc1071a34ddce9bb14b";
+        assert_eq!(hex::encode(root), expected_root);
+    }
+}

--- a/src/sparse/in_memory.rs
+++ b/src/sparse/in_memory.rs
@@ -5,7 +5,7 @@ use crate::{common, sparse};
 use alloc::boxed::Box;
 use core::pin::Pin;
 use core::ptr::NonNull;
-use std::marker::PhantomPinned;
+use core::marker::PhantomPinned;
 
 type StorageMap = common::StorageMap<Bytes32, Buffer>;
 type SparseMerkleTree<'a> = sparse::MerkleTree<'a, StorageMap>;

--- a/src/sparse/in_memory.rs
+++ b/src/sparse/in_memory.rs
@@ -41,6 +41,16 @@ impl<'a> MerkleTree<'a> {
         }
     }
 
+    pub fn delete(&mut self, key: &Bytes32) {
+        unsafe {
+            self.tree
+                .as_mut()
+                .unwrap_unchecked()
+                .delete(key)
+                .unwrap_unchecked();
+        }
+    }
+
     pub fn root(&self) -> Bytes32 {
         unsafe { self.tree.as_ref().unwrap_unchecked().root() }
     }
@@ -64,6 +74,56 @@ mod test {
         let mut tree = MerkleTree::new();
 
         tree.update(&sum(b"\x00\x00\x00\x00"), b"DATA");
+
+        let root = tree.root();
+        let expected_root = "39f36a7cb4dfb1b46f03d044265df6a491dffc1034121bc1071a34ddce9bb14b";
+        assert_eq!(hex::encode(root), expected_root);
+    }
+
+    #[test]
+    fn test_update_2() {
+        let mut tree = MerkleTree::new();
+
+        tree.update(&sum(b"\x00\x00\x00\x00"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x01"), b"DATA");
+
+        let root = tree.root();
+        let expected_root = "8d0ae412ca9ca0afcb3217af8bcd5a673e798bd6fd1dfacad17711e883f494cb";
+        assert_eq!(hex::encode(root), expected_root);
+    }
+
+    #[test]
+    fn test_update_3() {
+        let mut tree = MerkleTree::new();
+
+        tree.update(&sum(b"\x00\x00\x00\x00"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x01"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x02"), b"DATA");
+
+        let root = tree.root();
+        let expected_root = "52295e42d8de2505fdc0cc825ff9fead419cbcf540d8b30c7c4b9c9b94c268b7";
+        assert_eq!(hex::encode(root), expected_root);
+    }
+
+    #[test]
+    fn test_update_1_delete_1() {
+        let mut tree = MerkleTree::new();
+
+        tree.update(&sum(b"\x00\x00\x00\x00"), b"DATA");
+        tree.delete(&sum(b"\x00\x00\x00\x00"));
+
+        let root = tree.root();
+        let expected_root = "0000000000000000000000000000000000000000000000000000000000000000";
+        assert_eq!(hex::encode(root), expected_root);
+    }
+
+    #[test]
+    fn test_update_2_delete_1() {
+        let mut tree = MerkleTree::new();
+
+        tree.update(&sum(b"\x00\x00\x00\x00"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x01"), b"DATA");
+        tree.delete(&sum(b"\x00\x00\x00\x01"));
 
         let root = tree.root();
         let expected_root = "39f36a7cb4dfb1b46f03d044265df6a491dffc1034121bc1071a34ddce9bb14b";

--- a/src/sparse/in_memory.rs
+++ b/src/sparse/in_memory.rs
@@ -1,8 +1,8 @@
-use crate::sparse::{Buffer};
+use crate::common::Bytes32;
+use crate::sparse::Buffer;
 use crate::{common, sparse};
-use crate::common::{Bytes32};
+
 use std::pin::Pin;
-use std::marker::PhantomPinned;
 use std::ptr::NonNull;
 
 type StorageMap = common::StorageMap<Bytes32, Buffer>;
@@ -10,14 +10,14 @@ type SparseMerkleTree<'a> = sparse::MerkleTree<'a, StorageMap>;
 
 pub struct MerkleTree<'a> {
     storage: StorageMap,
-    tree: *mut SparseMerkleTree<'a>
+    tree: *mut SparseMerkleTree<'a>,
 }
 
 impl<'a> MerkleTree<'a> {
     pub fn new() -> Pin<Box<Self>> {
         let res = Self {
             storage: StorageMap::new(),
-            tree: std::ptr::null_mut()
+            tree: std::ptr::null_mut(),
         };
 
         let mut boxed = Box::pin(res);
@@ -31,20 +31,18 @@ impl<'a> MerkleTree<'a> {
         boxed
     }
 
-    pub fn update(
-        &mut self,
-        key: &Bytes32,
-        data: &[u8],
-    ) {
+    pub fn update(&mut self, key: &Bytes32, data: &[u8]) {
         unsafe {
-            self.tree.as_mut().unwrap_unchecked().update(key, data).unwrap_unchecked();
+            self.tree
+                .as_mut()
+                .unwrap_unchecked()
+                .update(key, data)
+                .unwrap_unchecked();
         }
     }
 
     pub fn root(&self) -> Bytes32 {
-        unsafe {
-            self.tree.as_ref().unwrap_unchecked().root()
-        }
+        unsafe { self.tree.as_ref().unwrap_unchecked().root() }
     }
 }
 
@@ -52,6 +50,14 @@ impl<'a> MerkleTree<'a> {
 mod test {
     use super::*;
     use sparse::hash::sum;
+
+    #[test]
+    fn test_empty_root() {
+        let tree = MerkleTree::new();
+        let root = tree.root();
+        let expected_root = "0000000000000000000000000000000000000000000000000000000000000000";
+        assert_eq!(hex::encode(root), expected_root);
+    }
 
     #[test]
     fn test_update_1() {

--- a/src/sparse/in_memory.rs
+++ b/src/sparse/in_memory.rs
@@ -10,14 +10,14 @@ type SparseMerkleTree<'a> = sparse::MerkleTree<'a, StorageMap>;
 
 pub struct MerkleTree<'a> {
     storage: StorageMap,
-    tree: *mut SparseMerkleTree<'a>,
+    tree_ptr: *mut SparseMerkleTree<'a>,
 }
 
 impl<'a> MerkleTree<'a> {
     pub fn new() -> Pin<Box<Self>> {
         let res = Self {
             storage: StorageMap::new(),
-            tree: std::ptr::null_mut(),
+            tree_ptr: std::ptr::null_mut(),
         };
 
         let mut boxed = Box::pin(res);
@@ -25,7 +25,7 @@ impl<'a> MerkleTree<'a> {
         unsafe {
             let mut storage = NonNull::from(&boxed.storage);
             let mut tree = Box::pin(SparseMerkleTree::new(storage.as_mut()));
-            boxed.tree = tree.as_mut().get_unchecked_mut();
+            boxed.tree_ptr = tree.as_mut().get_unchecked_mut();
         }
 
         boxed
@@ -33,7 +33,7 @@ impl<'a> MerkleTree<'a> {
 
     pub fn update(&mut self, key: &Bytes32, data: &[u8]) {
         unsafe {
-            self.tree
+            self.tree_ptr
                 .as_mut()
                 .unwrap_unchecked()
                 .update(key, data)
@@ -43,7 +43,7 @@ impl<'a> MerkleTree<'a> {
 
     pub fn delete(&mut self, key: &Bytes32) {
         unsafe {
-            self.tree
+            self.tree_ptr
                 .as_mut()
                 .unwrap_unchecked()
                 .delete(key)

--- a/src/sparse/in_memory.rs
+++ b/src/sparse/in_memory.rs
@@ -3,9 +3,9 @@ use crate::sparse::Buffer;
 use crate::{common, sparse};
 
 use alloc::boxed::Box;
+use core::marker::PhantomPinned;
 use core::pin::Pin;
 use core::ptr::NonNull;
-use core::marker::PhantomPinned;
 
 type StorageMap = common::StorageMap<Bytes32, Buffer>;
 type SparseMerkleTree<'a> = sparse::MerkleTree<'a, StorageMap>;

--- a/src/sparse/in_memory.rs
+++ b/src/sparse/in_memory.rs
@@ -2,6 +2,7 @@ use crate::common::Bytes32;
 use crate::sparse::Buffer;
 use crate::{common, sparse};
 
+use alloc::boxed::Box;
 use core::pin::Pin;
 use core::ptr::NonNull;
 

--- a/src/sum/merkle_tree.rs
+++ b/src/sum/merkle_tree.rs
@@ -4,6 +4,7 @@ use crate::sum::{empty_sum, Node};
 use fuel_storage::Storage;
 
 use alloc::boxed::Box;
+use core::fmt;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
@@ -12,16 +13,17 @@ pub enum MerkleTreeError {
     InvalidProofIndex(u64),
 }
 
-pub struct MerkleTree<'storage, StorageError> {
-    storage: &'storage mut dyn Storage<Bytes32, Node, Error = StorageError>,
+pub struct MerkleTree<StorageType> {
+    storage: StorageType,
     head: Option<Box<Subtree<Node>>>,
 }
 
-impl<'storage, StorageError> MerkleTree<'storage, StorageError>
+impl<StorageType, StorageError> MerkleTree<StorageType>
 where
-    StorageError: 'static + Clone,
+    StorageType: Storage<Bytes32, Node, Error = StorageError>,
+    StorageError: fmt::Debug + Clone + 'static,
 {
-    pub fn new(storage: &'storage mut dyn Storage<Bytes32, Node, Error = StorageError>) -> Self {
+    pub fn new(storage: StorageType) -> Self {
         Self {
             storage,
             head: None,
@@ -120,8 +122,7 @@ mod test {
     use crate::common::{Bytes32, StorageMap};
     use crate::sum::{empty_sum, leaf_sum, node_sum, MerkleTree, Node};
 
-    type StorageError = core::convert::Infallible;
-    type MT<'storage> = MerkleTree<'storage, StorageError>;
+    type MT<'storage> = MerkleTree<&'storage mut StorageMap<Bytes32, Node>>;
     const FEE: u64 = 100;
 
     #[test]

--- a/tests-data/tests-data.rs
+++ b/tests-data/tests-data.rs
@@ -1,12 +1,9 @@
-use std::{fs::File, path::Path};
-
-use core::pin::Pin;
-use fuel_merkle::common::{Bytes32, StorageMap};
+use fuel_merkle::common::Bytes32;
 use fuel_merkle::sparse::in_memory;
 use serde::Deserialize;
 use std::convert::TryInto;
 use std::fmt::{Display, Formatter};
-
+use std::{fs::File, path::Path};
 use thiserror::Error;
 
 #[derive(Clone, Debug, Error)]
@@ -122,11 +119,11 @@ impl Step {
     }
 }
 
-struct InMemoryMerkleTreeTestAdaptor<'a> {
-    tree: Pin<Box<in_memory::MerkleTree<'a>>>,
+struct InMemoryMerkleTreeTestAdaptor {
+    tree: Box<in_memory::MerkleTree>,
 }
 
-impl<'a> MerkleTreeTestAdaptor for InMemoryMerkleTreeTestAdaptor<'a> {
+impl<'a> MerkleTreeTestAdaptor for InMemoryMerkleTreeTestAdaptor {
     fn update(&mut self, key: &Bytes32, data: &[u8]) {
         self.tree.as_mut().update(key, data)
     }
@@ -149,7 +146,7 @@ struct Test {
 
 impl Test {
     pub fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
-        let mut tree = in_memory::MerkleTree::new();
+        let tree = Box::new(in_memory::MerkleTree::new());
         let mut tree = InMemoryMerkleTreeTestAdaptor { tree };
 
         for step in self.steps {

--- a/tests-data/tests-data.rs
+++ b/tests-data/tests-data.rs
@@ -1,7 +1,8 @@
 use std::{fs::File, path::Path};
 
+use core::pin::Pin;
 use fuel_merkle::common::{Bytes32, StorageMap};
-use fuel_merkle::sparse::MerkleTree as SparseMerkleTree;
+use fuel_merkle::sparse::in_memory;
 use serde::Deserialize;
 use std::convert::TryInto;
 use std::fmt::{Display, Formatter};
@@ -18,10 +19,10 @@ pub enum TestError {
     UnsupportedEncoding(String),
 }
 
-const BUFFER_SIZE: usize = 69;
-type Buffer = [u8; BUFFER_SIZE];
-type Storage = StorageMap<Bytes32, Buffer>;
-type MerkleTree<'a> = SparseMerkleTree<'a, Storage>;
+// const BUFFER_SIZE: usize = 69;
+// type Buffer = [u8; BUFFER_SIZE];
+// type Storage = StorageMap<Bytes32, Buffer>;
+// type MerkleTree<'a> = SparseMerkleTree<'a, Storage>;
 
 // Supported actions:
 const ACTION_UPDATE: &str = "update";
@@ -64,6 +65,12 @@ impl EncodedValue {
     }
 }
 
+trait MerkleTreeTestAdaptor {
+    fn update(&mut self, key: &Bytes32, data: &[u8]);
+    fn delete(&mut self, key: &Bytes32);
+    fn root(&self) -> Bytes32;
+}
+
 #[derive(Deserialize)]
 struct Step {
     action: String,
@@ -77,20 +84,23 @@ enum Action {
 }
 
 impl Step {
-    pub fn execute(self, tree: &mut MerkleTree) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn execute(
+        self,
+        tree: &mut dyn MerkleTreeTestAdaptor,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         match self.action_type()? {
             Action::Update(encoded_key, encoded_data) => {
                 let key_bytes = encoded_key.to_bytes()?;
                 let key = &key_bytes.try_into().unwrap();
                 let data_bytes = encoded_data.to_bytes()?;
                 let data: &[u8] = &data_bytes;
-                tree.update(key, data).unwrap();
+                tree.update(key, data);
                 Ok(())
             }
             Action::Delete(encoded_key) => {
                 let key_bytes = encoded_key.to_bytes()?;
                 let key = &key_bytes.try_into().unwrap();
-                tree.delete(key).unwrap();
+                tree.delete(key);
                 Ok(())
             }
         }
@@ -117,6 +127,24 @@ impl Step {
     }
 }
 
+struct InMemoryMerkleTreeTestAdaptor<'a> {
+    tree: Pin<Box<in_memory::MerkleTree<'a>>>,
+}
+
+impl<'a> MerkleTreeTestAdaptor for InMemoryMerkleTreeTestAdaptor<'a> {
+    fn update(&mut self, key: &Bytes32, data: &[u8]) {
+        self.tree.as_mut().update(key, data)
+    }
+
+    fn delete(&mut self, key: &Bytes32) {
+        self.tree.as_mut().delete(key)
+    }
+
+    fn root(&self) -> Bytes32 {
+        self.tree.as_ref().root()
+    }
+}
+
 #[derive(Deserialize)]
 struct Test {
     name: String,
@@ -126,8 +154,8 @@ struct Test {
 
 impl Test {
     pub fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
-        let mut storage = StorageMap::<Bytes32, Buffer>::new();
-        let mut tree = MerkleTree::new(&mut storage);
+        let mut tree = in_memory::MerkleTree::new();
+        let mut tree = InMemoryMerkleTreeTestAdaptor { tree };
 
         for step in self.steps {
             step.execute(&mut tree)?

--- a/tests-data/tests-data.rs
+++ b/tests-data/tests-data.rs
@@ -19,11 +19,6 @@ pub enum TestError {
     UnsupportedEncoding(String),
 }
 
-// const BUFFER_SIZE: usize = 69;
-// type Buffer = [u8; BUFFER_SIZE];
-// type Storage = StorageMap<Bytes32, Buffer>;
-// type MerkleTree<'a> = SparseMerkleTree<'a, Storage>;
-
 // Supported actions:
 const ACTION_UPDATE: &str = "update";
 const ACTION_DELETE: &str = "delete";


### PR DESCRIPTION
Related issues:
- Closes https://github.com/FuelLabs/fuel-merkle/issues/93

This PR adds an infallible, in-memory type for the Sparse Merkle Tree. 

Because the default in-memory storage type, `StorageMap`, is infallible, i.e. never returns an error, we know that the wrapping SMT is also infallible for common storage based operations, specifically `update` and `delete`. 

The in-memory type prescribes using the default `StorageMap` as its storage type. This allows us to simplify the signature of the in-memory SMT constructor by removing the need to supply a storage reference. Instead, the in-memory SMT owns a storage instance of type `StorageMap`, and internally constructs a regular SMT around this storage. 

This creates a self-referential structure: the internal SMT refers to the the internal storage object. Therefore, the in-memory SMT uses a `Pin<Box<...>>` and allocates the in-memory SMT on the heap. This ensures that the storage map has a consistent address and the internal SMT has a perpetually valid reference to this address.  

I'm also updating the data driven tests to use this in-memory Merkle tree to ensure that this tree is getting adequate test coverage. Soon, I would like to update the data driven test architecture to better support testing multiple implementations. As it stands, it is designed to only test a specific implementation, and testing other impls would require duplicating the entire framework.