### PR TITLE
Relax constraint on Storage

### DIFF
--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use crate::binary::{self, Node};
 use crate::common::{Bytes32, Position, Subtree};
 use fuel_storage::Storage;
@@ -29,18 +31,18 @@ impl<StorageError> From<StorageError> for MerkleTreeError<StorageError> {
 
 type ProofSet = Vec<Bytes32>;
 
-pub struct MerkleTree<'storage, StorageType> {
-    storage: &'storage mut StorageType,
+pub struct MerkleTree<StorageType> {
+    storage: StorageType,
     head: Option<Box<Subtree<Node>>>,
     leaves_count: u64,
 }
 
-impl<'storage, StorageType, StorageError> MerkleTree<'storage, StorageType>
+impl<StorageType, StorageError> MerkleTree<StorageType>
 where
     StorageType: Storage<u64, Node, Error = StorageError>,
-    StorageError: 'static,
+    StorageError: fmt::Debug + Clone + 'static,
 {
-    pub fn new(storage: &'storage mut StorageType) -> Self {
+    pub fn new(storage: StorageType) -> Self {
         Self {
             storage,
             head: None,
@@ -49,7 +51,7 @@ where
     }
 
     pub fn load(
-        storage: &'storage mut StorageType,
+        storage: StorageType,
         leaves_count: u64,
     ) -> Result<Self, MerkleTreeError<StorageError>> {
         let mut tree = Self {

--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -1,6 +1,5 @@
 use crate::binary::{self, Node};
 use crate::common::{Bytes32, Position, Subtree};
-
 use fuel_storage::Storage;
 
 use alloc::boxed::Box;

--- a/src/sparse/in_memory.rs
+++ b/src/sparse/in_memory.rs
@@ -2,62 +2,30 @@ use crate::common::Bytes32;
 use crate::sparse::Buffer;
 use crate::{common, sparse};
 
-use alloc::boxed::Box;
-use core::marker::PhantomPinned;
-use core::pin::Pin;
-use core::ptr::NonNull;
-
 type StorageMap = common::StorageMap<Bytes32, Buffer>;
-type SparseMerkleTree<'a> = sparse::MerkleTree<'a, StorageMap>;
+type SparseMerkleTree = sparse::MerkleTree<StorageMap>;
 
-pub struct MerkleTree<'a> {
-    storage: StorageMap,
-    tree: Option<SparseMerkleTree<'a>>,
-    _marker: PhantomPinned,
+pub struct MerkleTree {
+    tree: SparseMerkleTree,
 }
 
-impl<'a> MerkleTree<'a> {
-    pub fn new() -> Pin<Box<Self>> {
-        let res = Self {
-            storage: StorageMap::new(),
-            tree: None,
-            _marker: PhantomPinned,
-        };
-
-        let mut boxed = Box::pin(res);
-
-        unsafe {
-            let mut storage = NonNull::from(&boxed.storage);
-            boxed.as_mut().get_unchecked_mut().tree = Some(SparseMerkleTree::new(storage.as_mut()));
-        }
-
-        boxed
-    }
-
-    pub fn update(self: Pin<&mut Self>, key: &Bytes32, data: &[u8]) {
-        unsafe {
-            self.get_unchecked_mut()
-                .tree
-                .as_mut()
-                .unwrap_unchecked()
-                .update(key, data)
-                .unwrap_unchecked();
+impl MerkleTree {
+    pub fn new() -> Self {
+        Self {
+            tree: SparseMerkleTree::new(StorageMap::new()),
         }
     }
 
-    pub fn delete(self: Pin<&mut Self>, key: &Bytes32) {
-        unsafe {
-            self.get_unchecked_mut()
-                .tree
-                .as_mut()
-                .unwrap_unchecked()
-                .delete(key)
-                .unwrap_unchecked();
-        }
+    pub fn update(&mut self, key: &Bytes32, data: &[u8]) {
+        let _ = self.tree.update(key, data);
     }
 
-    pub fn root(self: Pin<&Self>) -> Bytes32 {
-        unsafe { self.tree.as_ref().unwrap_unchecked().root() }
+    pub fn delete(&mut self, key: &Bytes32) {
+        let _ = self.tree.delete(key);
+    }
+
+    pub fn root(&self) -> Bytes32 {
+        self.tree.root()
     }
 }
 
@@ -69,7 +37,7 @@ mod test {
     #[test]
     fn test_empty_root() {
         let tree = MerkleTree::new();
-        let root = tree.as_ref().root();
+        let root = tree.root();
         let expected_root = "0000000000000000000000000000000000000000000000000000000000000000";
         assert_eq!(hex::encode(root), expected_root);
     }
@@ -78,9 +46,9 @@ mod test {
     fn test_update_1() {
         let mut tree = MerkleTree::new();
 
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x00"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x00"), b"DATA");
 
-        let root = tree.as_ref().root();
+        let root = tree.root();
         let expected_root = "39f36a7cb4dfb1b46f03d044265df6a491dffc1034121bc1071a34ddce9bb14b";
         assert_eq!(hex::encode(root), expected_root);
     }
@@ -89,10 +57,10 @@ mod test {
     fn test_update_2() {
         let mut tree = MerkleTree::new();
 
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x00"), b"DATA");
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x01"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x00"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x01"), b"DATA");
 
-        let root = tree.as_ref().root();
+        let root = tree.root();
         let expected_root = "8d0ae412ca9ca0afcb3217af8bcd5a673e798bd6fd1dfacad17711e883f494cb";
         assert_eq!(hex::encode(root), expected_root);
     }
@@ -101,11 +69,11 @@ mod test {
     fn test_update_3() {
         let mut tree = MerkleTree::new();
 
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x00"), b"DATA");
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x01"), b"DATA");
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x02"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x00"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x01"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x02"), b"DATA");
 
-        let root = tree.as_ref().root();
+        let root = tree.root();
         let expected_root = "52295e42d8de2505fdc0cc825ff9fead419cbcf540d8b30c7c4b9c9b94c268b7";
         assert_eq!(hex::encode(root), expected_root);
     }
@@ -114,10 +82,10 @@ mod test {
     fn test_update_1_delete_1() {
         let mut tree = MerkleTree::new();
 
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x00"), b"DATA");
-        tree.as_mut().delete(&sum(b"\x00\x00\x00\x00"));
+        tree.update(&sum(b"\x00\x00\x00\x00"), b"DATA");
+        tree.delete(&sum(b"\x00\x00\x00\x00"));
 
-        let root = tree.as_ref().root();
+        let root = tree.root();
         let expected_root = "0000000000000000000000000000000000000000000000000000000000000000";
         assert_eq!(hex::encode(root), expected_root);
     }
@@ -126,11 +94,11 @@ mod test {
     fn test_update_2_delete_1() {
         let mut tree = MerkleTree::new();
 
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x00"), b"DATA");
-        tree.as_mut().update(&sum(b"\x00\x00\x00\x01"), b"DATA");
-        tree.as_mut().delete(&sum(b"\x00\x00\x00\x01"));
+        tree.update(&sum(b"\x00\x00\x00\x00"), b"DATA");
+        tree.update(&sum(b"\x00\x00\x00\x01"), b"DATA");
+        tree.delete(&sum(b"\x00\x00\x00\x01"));
 
-        let root = tree.as_ref().root();
+        let root = tree.root();
         let expected_root = "39f36a7cb4dfb1b46f03d044265df6a491dffc1034121bc1071a34ddce9bb14b";
         assert_eq!(hex::encode(root), expected_root);
     }

--- a/src/sparse/merkle_tree.rs
+++ b/src/sparse/merkle_tree.rs
@@ -1,6 +1,5 @@
 use crate::common::{AsPathIterator, Bytes32};
 use crate::sparse::{zero_sum, Buffer, Node, StorageNode};
-
 use fuel_storage::Storage;
 
 use alloc::string::String;
@@ -31,7 +30,7 @@ pub struct MerkleTree<StorageType> {
     storage: StorageType,
 }
 
-impl<'a, StorageType, StorageError> MerkleTree<StorageType>
+impl<StorageType, StorageError> MerkleTree<StorageType>
 where
     StorageType: Storage<Bytes32, Buffer, Error = StorageError>,
     StorageError: fmt::Debug + Clone + 'static,
@@ -59,7 +58,7 @@ where
     }
 
     pub fn update(
-        &'a mut self,
+        &mut self,
         key: &Bytes32,
         data: &[u8],
     ) -> Result<(), MerkleTreeError<StorageError>> {
@@ -86,7 +85,7 @@ where
         Ok(())
     }
 
-    pub fn delete(&'a mut self, key: &Bytes32) -> Result<(), MerkleTreeError<StorageError>> {
+    pub fn delete(&mut self, key: &Bytes32) -> Result<(), MerkleTreeError<StorageError>> {
         if self.root() == *zero_sum() {
             // The zero root signifies that all leaves are empty, including the
             // given key.
@@ -102,22 +101,22 @@ where
         Ok(())
     }
 
-    pub fn root(&'a self) -> Bytes32 {
+    pub fn root(&self) -> Bytes32 {
         self.root_node().hash()
     }
 
     // PRIVATE
 
-    fn root_node(&'a self) -> &Node {
+    fn root_node(&self) -> &Node {
         &self.root_node
     }
 
-    fn set_root_node(&'a mut self, node: Node) {
+    fn set_root_node(&mut self, node: Node) {
         debug_assert!(node.is_leaf() || node.height() == Node::max_height() as u32);
         self.root_node = node;
     }
 
-    fn path_set(&'a self, leaf_node: Node) -> (Vec<Node>, Vec<Node>) {
+    fn path_set(&self, leaf_node: Node) -> (Vec<Node>, Vec<Node>) {
         let root_node = self.root_node().clone();
         let root_storage_node = StorageNode::new(&self.storage, root_node);
         let leaf_storage_node = StorageNode::new(&self.storage, leaf_node);
@@ -133,7 +132,7 @@ where
     }
 
     fn update_with_path_set(
-        &'a mut self,
+        &mut self,
         requested_leaf_node: &Node,
         path_nodes: &[Node],
         side_nodes: &[Node],
@@ -197,7 +196,7 @@ where
     }
 
     fn delete_with_path_set(
-        &'a mut self,
+        &mut self,
         requested_leaf_node: &Node,
         path_nodes: &[Node],
         side_nodes: &[Node],

--- a/src/sparse/merkle_tree.rs
+++ b/src/sparse/merkle_tree.rs
@@ -26,17 +26,17 @@ impl<StorageError> From<StorageError> for MerkleTreeError<StorageError> {
     }
 }
 
-pub struct MerkleTree<'storage, StorageType> {
+pub struct MerkleTree<StorageType> {
     root_node: Node,
-    storage: &'storage mut StorageType,
+    storage: StorageType,
 }
 
-impl<'a, 'storage, StorageType, StorageError> MerkleTree<'storage, StorageType>
+impl<'a, StorageType, StorageError> MerkleTree<StorageType>
 where
     StorageType: Storage<Bytes32, Buffer, Error = StorageError>,
     StorageError: fmt::Debug + Clone + 'static,
 {
-    pub fn new(storage: &'storage mut StorageType) -> Self {
+    pub fn new(storage: StorageType) -> Self {
         Self {
             root_node: Node::create_placeholder(),
             storage,
@@ -44,7 +44,7 @@ where
     }
 
     pub fn load(
-        storage: &'storage mut StorageType,
+        storage: StorageType,
         root: &Bytes32,
     ) -> Result<Self, MerkleTreeError<StorageError>> {
         let buffer = storage
@@ -119,8 +119,8 @@ where
 
     fn path_set(&'a self, leaf_node: Node) -> (Vec<Node>, Vec<Node>) {
         let root_node = self.root_node().clone();
-        let root_storage_node = StorageNode::new(self.storage, root_node);
-        let leaf_storage_node = StorageNode::new(self.storage, leaf_node);
+        let root_storage_node = StorageNode::new(&self.storage, root_node);
+        let leaf_storage_node = StorageNode::new(&self.storage, leaf_node);
         let (mut path_nodes, mut side_nodes): (Vec<Node>, Vec<Node>) = root_storage_node
             .as_path_iter(&leaf_storage_node)
             .map(|(node, side_node)| (node.into_node(), side_node.into_node()))

--- a/src/sum/merkle_tree.rs
+++ b/src/sum/merkle_tree.rs
@@ -4,6 +4,7 @@ use crate::sum::{empty_sum, Node};
 use fuel_storage::Storage;
 
 use alloc::boxed::Box;
+use core::fmt;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
@@ -12,16 +13,17 @@ pub enum MerkleTreeError {
     InvalidProofIndex(u64),
 }
 
-pub struct MerkleTree<'storage, StorageError> {
-    storage: &'storage mut dyn Storage<Bytes32, Node, Error = StorageError>,
+pub struct MerkleTree<StorageType> {
+    storage: StorageType,
     head: Option<Box<Subtree<Node>>>,
 }
 
-impl<'storage, StorageError> MerkleTree<'storage, StorageError>
+impl<StorageType, StorageError> MerkleTree<StorageType>
 where
-    StorageError: 'static + Clone,
+    StorageType: Storage<Bytes32, Node, Error = StorageError>,
+    StorageError: fmt::Debug + Clone + 'static,
 {
-    pub fn new(storage: &'storage mut dyn Storage<Bytes32, Node, Error = StorageError>) -> Self {
+    pub fn new(storage: StorageType) -> Self {
         Self {
             storage,
             head: None,
@@ -120,8 +122,7 @@ mod test {
     use crate::common::{Bytes32, StorageMap};
     use crate::sum::{empty_sum, leaf_sum, node_sum, MerkleTree, Node};
 
-    type StorageError = core::convert::Infallible;
-    type MT<'storage> = MerkleTree<'storage, StorageError>;
+    type MT<'storage> = MerkleTree<&'storage mut StorageMap<Bytes32, Node>>;
     const FEE: u64 = 100;
 
     #[test]

--- a/tests-data/tests-data.rs
+++ b/tests-data/tests-data.rs
@@ -1,12 +1,9 @@
-use std::{fs::File, path::Path};
-
-use core::pin::Pin;
-use fuel_merkle::common::{Bytes32, StorageMap};
+use fuel_merkle::common::Bytes32;
 use fuel_merkle::sparse::in_memory;
 use serde::Deserialize;
 use std::convert::TryInto;
 use std::fmt::{Display, Formatter};
-
+use std::{fs::File, path::Path};
 use thiserror::Error;
 
 #[derive(Clone, Debug, Error)]
@@ -122,11 +119,11 @@ impl Step {
     }
 }
 
-struct InMemoryMerkleTreeTestAdaptor<'a> {
-    tree: Pin<Box<in_memory::MerkleTree<'a>>>,
+struct InMemoryMerkleTreeTestAdaptor {
+    tree: Box<in_memory::MerkleTree>,
 }
 
-impl<'a> MerkleTreeTestAdaptor for InMemoryMerkleTreeTestAdaptor<'a> {
+impl<'a> MerkleTreeTestAdaptor for InMemoryMerkleTreeTestAdaptor {
     fn update(&mut self, key: &Bytes32, data: &[u8]) {
         self.tree.as_mut().update(key, data)
     }
@@ -149,7 +146,7 @@ struct Test {
 
 impl Test {
     pub fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
-        let mut tree = in_memory::MerkleTree::new();
+        let tree = Box::new(in_memory::MerkleTree::new());
         let mut tree = InMemoryMerkleTreeTestAdaptor { tree };
 
         for step in self.steps {


### PR DESCRIPTION
It is perfectly fine to use generic as storage and not its reference, as `Storage` implements `&mut` for its trait here: https://github.com/FuelLabs/fuel-storage/blob/21319d8412edda0dc1387ca201408ccb8c112d6b/src/lib.rs#L43
And rust will be able to match both storage and &mut storage bcs of that.

Added change for both sparse and sum Merkle tree