### PR TITLE
cargo clippy lints

### DIFF
--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -79,7 +79,7 @@ where
         proof_index: u64,
     ) -> Result<(Bytes32, ProofSet), MerkleTreeError<StorageError>> {
         if proof_index + 1 > self.leaves_count {
-            return Err(MerkleTreeError::InvalidProofIndex(proof_index).into());
+            return Err(MerkleTreeError::InvalidProofIndex(proof_index));
         }
 
         let mut proof_set = ProofSet::new();
@@ -224,13 +224,13 @@ mod test {
         // 00  02  04  06  08  10     12
         // 00  01  02  03  04  05     06
 
-        let leaf_0 = leaf_sum(&data[0]);
-        let leaf_1 = leaf_sum(&data[1]);
-        let leaf_2 = leaf_sum(&data[2]);
-        let leaf_3 = leaf_sum(&data[3]);
-        let leaf_4 = leaf_sum(&data[4]);
-        let leaf_5 = leaf_sum(&data[5]);
-        let leaf_6 = leaf_sum(&data[6]);
+        let leaf_0 = leaf_sum(data[0]);
+        let leaf_1 = leaf_sum(data[1]);
+        let leaf_2 = leaf_sum(data[2]);
+        let leaf_3 = leaf_sum(data[3]);
+        let leaf_4 = leaf_sum(data[4]);
+        let leaf_5 = leaf_sum(data[5]);
+        let leaf_6 = leaf_sum(data[6]);
         let node_1 = node_sum(&leaf_0, &leaf_1);
         let node_5 = node_sum(&leaf_2, &leaf_3);
         let node_3 = node_sum(&node_1, &node_5);
@@ -321,7 +321,7 @@ mod test {
             let _ = tree.push(datum);
         }
 
-        let leaf_0 = leaf_sum(&data[0]);
+        let leaf_0 = leaf_sum(data[0]);
 
         let root = tree.root().unwrap();
         assert_eq!(root, leaf_0);
@@ -352,13 +352,13 @@ mod test {
         // 00  02  04  06  08  10     12
         // 00  01  02  03  04  05     06
 
-        let leaf_0 = leaf_sum(&data[0]);
-        let leaf_1 = leaf_sum(&data[1]);
-        let leaf_2 = leaf_sum(&data[2]);
-        let leaf_3 = leaf_sum(&data[3]);
-        let leaf_4 = leaf_sum(&data[4]);
-        let leaf_5 = leaf_sum(&data[5]);
-        let leaf_6 = leaf_sum(&data[6]);
+        let leaf_0 = leaf_sum(data[0]);
+        let leaf_1 = leaf_sum(data[1]);
+        let leaf_2 = leaf_sum(data[2]);
+        let leaf_3 = leaf_sum(data[3]);
+        let leaf_4 = leaf_sum(data[4]);
+        let leaf_5 = leaf_sum(data[5]);
+        let leaf_6 = leaf_sum(data[6]);
 
         let node_1 = node_sum(&leaf_0, &leaf_1);
         let node_5 = node_sum(&leaf_2, &leaf_3);
@@ -404,7 +404,7 @@ mod test {
             let _ = tree.push(datum);
         }
 
-        let leaf_0 = leaf_sum(&data[0]);
+        let leaf_0 = leaf_sum(data[0]);
 
         {
             let proof = tree.prove(0).unwrap();
@@ -434,10 +434,10 @@ mod test {
         // 00  02  04  06
         // 00  01  02  03
 
-        let leaf_0 = leaf_sum(&data[0]);
-        let leaf_1 = leaf_sum(&data[1]);
-        let leaf_2 = leaf_sum(&data[2]);
-        let leaf_3 = leaf_sum(&data[3]);
+        let leaf_0 = leaf_sum(data[0]);
+        let leaf_1 = leaf_sum(data[1]);
+        let leaf_2 = leaf_sum(data[2]);
+        let leaf_3 = leaf_sum(data[3]);
 
         let node_1 = node_sum(&leaf_0, &leaf_1);
         let node_5 = node_sum(&leaf_2, &leaf_3);
@@ -506,11 +506,11 @@ mod test {
         // 00  02  04  06  08
         // 00  01  02  03  04
 
-        let leaf_0 = leaf_sum(&data[0]);
-        let leaf_1 = leaf_sum(&data[1]);
-        let leaf_2 = leaf_sum(&data[2]);
-        let leaf_3 = leaf_sum(&data[3]);
-        let leaf_4 = leaf_sum(&data[4]);
+        let leaf_0 = leaf_sum(data[0]);
+        let leaf_1 = leaf_sum(data[1]);
+        let leaf_2 = leaf_sum(data[2]);
+        let leaf_3 = leaf_sum(data[3]);
+        let leaf_4 = leaf_sum(data[4]);
 
         let node_1 = node_sum(&leaf_0, &leaf_1);
         let node_5 = node_sum(&leaf_2, &leaf_3);
@@ -597,13 +597,13 @@ mod test {
         // 00  02  04  06  08  10     12
         // 00  01  02  03  04  05     06
 
-        let leaf_0 = leaf_sum(&data[0]);
-        let leaf_1 = leaf_sum(&data[1]);
-        let leaf_2 = leaf_sum(&data[2]);
-        let leaf_3 = leaf_sum(&data[3]);
-        let leaf_4 = leaf_sum(&data[4]);
-        let leaf_5 = leaf_sum(&data[5]);
-        let leaf_6 = leaf_sum(&data[6]);
+        let leaf_0 = leaf_sum(data[0]);
+        let leaf_1 = leaf_sum(data[1]);
+        let leaf_2 = leaf_sum(data[2]);
+        let leaf_3 = leaf_sum(data[3]);
+        let leaf_4 = leaf_sum(data[4]);
+        let leaf_5 = leaf_sum(data[5]);
+        let leaf_6 = leaf_sum(data[6]);
 
         let node_1 = node_sum(&leaf_0, &leaf_1);
         let node_5 = node_sum(&leaf_2, &leaf_3);

--- a/src/common/position_path.rs
+++ b/src/common/position_path.rs
@@ -56,7 +56,7 @@ impl Iterator for PositionPathIter {
     type Item = (Position, Position);
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some((path, mut side)) = self.path_iter.next() {
+        for (path, mut side) in self.path_iter.by_ref() {
             // To determine if the position is in the tree, we observe that the
             // highest in-order index belongs to the tree's rightmost leaf
             // position (as defined by the `leaves_count` parameter) and that

--- a/src/common/storage_map.rs
+++ b/src/common/storage_map.rs
@@ -8,6 +8,12 @@ pub struct StorageMap<Key, Value> {
     map: HashMap<Key, Value>,
 }
 
+impl<Key, Value> Default for StorageMap<Key, Value> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<Key, Value> StorageMap<Key, Value> {
     pub fn new() -> Self {
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::bool_assert_comparison, clippy::identity_op)]
 
 #[cfg_attr(test, macro_use)]
 extern crate alloc;

--- a/src/sparse/merkle_tree.rs
+++ b/src/sparse/merkle_tree.rs
@@ -49,7 +49,7 @@ where
     ) -> Result<Self, MerkleTreeError<StorageError>> {
         let buffer = storage
             .get(root)?
-            .ok_or(MerkleTreeError::LoadError(hex::encode(root)))?
+            .ok_or_else(|| MerkleTreeError::LoadError(hex::encode(root)))?
             .into_owned();
         let tree = Self {
             root_node: Node::from_buffer(buffer),
@@ -74,7 +74,7 @@ where
         self.storage
             .insert(&leaf_node.hash(), leaf_node.as_buffer())?;
         self.storage
-            .insert(&leaf_node.leaf_key(), leaf_node.as_buffer())?;
+            .insert(leaf_node.leaf_key(), leaf_node.as_buffer())?;
 
         if self.root_node().is_placeholder() {
             self.set_root_node(leaf_node);
@@ -222,27 +222,31 @@ where
         // calculation. We then create a valid ancestor node for the orphaned
         // leaf node by joining it with the earliest non-placeholder side node.
         let first_side_node = side_nodes.first();
-        if first_side_node.is_some() && first_side_node.unwrap().is_leaf() {
-            side_nodes_iter.next();
-            current_node = first_side_node.unwrap().clone();
+        if let Some(first_side_node) = first_side_node {
+            if first_side_node.is_leaf() {
+                side_nodes_iter.next();
+                current_node = first_side_node.clone();
 
-            // Advance the side node iterator to the next non-placeholder node.
-            // This may be either another leaf node or an internal node. If only
-            // placeholder nodes exist beyond the first leaf node, then that
-            // leaf node is, in fact, the new root node.
-            //
-            // Using `find(..)` advances the iterator beyond the next
-            // non-placeholder side node and returns it. Therefore, we must
-            // consume the side node at this point. If another non-placeholder
-            // node was found in the side node collection, merge it with the
-            // first side node. This guarantees that the current node will be an
-            // internal node, and not a leaf, by the time we start merging the
-            // remaining side nodes.
-            // See https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.find.
-            if let Some(side_node) = side_nodes_iter.find(|side_node| !side_node.is_placeholder()) {
-                current_node = Node::create_node_on_path(path, &current_node, side_node);
-                self.storage
-                    .insert(&current_node.hash(), current_node.as_buffer())?;
+                // Advance the side node iterator to the next non-placeholder node.
+                // This may be either another leaf node or an internal node. If only
+                // placeholder nodes exist beyond the first leaf node, then that
+                // leaf node is, in fact, the new root node.
+                //
+                // Using `find(..)` advances the iterator beyond the next
+                // non-placeholder side node and returns it. Therefore, we must
+                // consume the side node at this point. If another non-placeholder
+                // node was found in the side node collection, merge it with the
+                // first side node. This guarantees that the current node will be an
+                // internal node, and not a leaf, by the time we start merging the
+                // remaining side nodes.
+                // See https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.find.
+                if let Some(side_node) =
+                    side_nodes_iter.find(|side_node| !side_node.is_placeholder())
+                {
+                    current_node = Node::create_node_on_path(path, &current_node, side_node);
+                    self.storage
+                        .insert(&current_node.hash(), current_node.as_buffer())?;
+                }
             }
         }
 

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -70,7 +70,6 @@ impl Node {
             } else {
                 Node::create_node(side_node, path_node, parent_height)
             }
-            // parent_node
         } else {
             // When joining two nodes, or a node and a leaf, the joined node is
             // the direct parent of the node with the greater height and an
@@ -83,7 +82,6 @@ impl Node {
             } else {
                 Node::create_node(side_node, path_node, parent_height)
             }
-            // parent_node
         }
     }
 

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -65,12 +65,12 @@ impl Node {
             // N.B.: A leaf can be a placeholder.
             let parent_depth = path_node.common_path_length(side_node);
             let parent_height = (Node::max_height() - parent_depth) as u32;
-            let parent_node = if path.get_bit_at_index_from_msb(parent_depth).unwrap() == LEFT {
-                Node::create_node(&path_node, &side_node, parent_height)
+            if path.get_bit_at_index_from_msb(parent_depth).unwrap() == LEFT {
+                Node::create_node(path_node, side_node, parent_height)
             } else {
-                Node::create_node(&side_node, &path_node, parent_height)
-            };
-            parent_node
+                Node::create_node(side_node, path_node, parent_height)
+            }
+            // parent_node
         } else {
             // When joining two nodes, or a node and a leaf, the joined node is
             // the direct parent of the node with the greater height and an
@@ -78,12 +78,12 @@ impl Node {
             // N.B.: A leaf can be a placeholder.
             let parent_height = cmp::max(path_node.height(), side_node.height()) + 1;
             let parent_depth = Node::max_height() - parent_height as usize;
-            let parent_node = if path.get_bit_at_index_from_msb(parent_depth).unwrap() == LEFT {
-                Node::create_node(&path_node, &side_node, parent_height)
+            if path.get_bit_at_index_from_msb(parent_depth).unwrap() == LEFT {
+                Node::create_node(path_node, side_node, parent_height)
             } else {
-                Node::create_node(&side_node, &path_node, parent_height)
-            };
-            parent_node
+                Node::create_node(side_node, path_node, parent_height)
+            }
+            // parent_node
         }
     }
 
@@ -676,7 +676,7 @@ mod test_storage_node {
         let node_0 = Node::create_node(&leaf_0, &leaf_1, 1);
         let _ = s.insert(&node_0.hash(), node_0.as_buffer());
 
-        let storage_node = StorageNode::new(&mut s, node_0);
+        let storage_node = StorageNode::new(&s, node_0);
         let child = storage_node.left_child().unwrap();
 
         assert_eq!(child.hash(), leaf_0.hash());
@@ -695,7 +695,7 @@ mod test_storage_node {
         let node_0 = Node::create_node(&leaf_0, &leaf_1, 1);
         let _ = s.insert(&node_0.hash(), node_0.as_buffer());
 
-        let storage_node = StorageNode::new(&mut s, node_0);
+        let storage_node = StorageNode::new(&s, node_0);
         let child = storage_node.right_child().unwrap();
 
         assert_eq!(child.hash(), leaf_1.hash());
@@ -711,7 +711,7 @@ mod test_storage_node {
         let node_0 = Node::create_node(&Node::create_placeholder(), &leaf, 1);
         let _ = s.insert(&node_0.hash(), node_0.as_buffer());
 
-        let storage_node = StorageNode::new(&mut s, node_0);
+        let storage_node = StorageNode::new(&s, node_0);
         let child = storage_node.left_child().unwrap();
 
         assert!(child.node.is_placeholder());
@@ -727,7 +727,7 @@ mod test_storage_node {
         let node_0 = Node::create_node(&leaf, &Node::create_placeholder(), 1);
         let _ = s.insert(&node_0.hash(), node_0.as_buffer());
 
-        let storage_node = StorageNode::new(&mut s, node_0);
+        let storage_node = StorageNode::new(&s, node_0);
         let child = storage_node.right_child().unwrap();
 
         assert!(child.node.is_placeholder());

--- a/src/sum/merkle_tree.rs
+++ b/src/sum/merkle_tree.rs
@@ -130,7 +130,7 @@ mod test {
         let mut tree = MT::new(&mut storage_map);
 
         let root = tree.root().unwrap();
-        assert_eq!(root, (0, empty_sum().clone()));
+        assert_eq!(root, (0, *empty_sum()));
     }
 
     #[test]
@@ -139,10 +139,10 @@ mod test {
         let mut tree = MT::new(&mut storage_map);
 
         let data = &TEST_DATA[0];
-        let _ = tree.push(FEE, &data);
+        let _ = tree.push(FEE, data);
         let root = tree.root().unwrap();
 
-        let expected = (FEE, leaf_sum(FEE, &data));
+        let expected = (FEE, leaf_sum(FEE, data));
         assert_eq!(root, expected);
     }
 
@@ -164,10 +164,10 @@ mod test {
         //  /  \    /  \
         // L0  L1  L2  L3
 
-        let leaf_0 = leaf_sum(FEE, &data[0]);
-        let leaf_1 = leaf_sum(FEE, &data[1]);
-        let leaf_2 = leaf_sum(FEE, &data[2]);
-        let leaf_3 = leaf_sum(FEE, &data[3]);
+        let leaf_0 = leaf_sum(FEE, data[0]);
+        let leaf_1 = leaf_sum(FEE, data[1]);
+        let leaf_2 = leaf_sum(FEE, data[2]);
+        let leaf_3 = leaf_sum(FEE, data[3]);
 
         let node_0 = node_sum(FEE * 1, &leaf_0, FEE * 1, &leaf_1);
         let node_1 = node_sum(FEE * 1, &leaf_2, FEE * 1, &leaf_3);
@@ -197,11 +197,11 @@ mod test {
         //  /  \    /  \   \
         // L0  L1  L2  L3  L4
 
-        let leaf_0 = leaf_sum(FEE, &data[0]);
-        let leaf_1 = leaf_sum(FEE, &data[1]);
-        let leaf_2 = leaf_sum(FEE, &data[2]);
-        let leaf_3 = leaf_sum(FEE, &data[3]);
-        let leaf_4 = leaf_sum(FEE, &data[4]);
+        let leaf_0 = leaf_sum(FEE, data[0]);
+        let leaf_1 = leaf_sum(FEE, data[1]);
+        let leaf_2 = leaf_sum(FEE, data[2]);
+        let leaf_3 = leaf_sum(FEE, data[3]);
+        let leaf_4 = leaf_sum(FEE, data[4]);
 
         let node_0 = node_sum(FEE * 1, &leaf_0, FEE * 1, &leaf_1);
         let node_1 = node_sum(FEE * 1, &leaf_2, FEE * 1, &leaf_3);
@@ -235,13 +235,13 @@ mod test {
         //  /  \    /  \    /  \   \
         // L0  L1  L2  L3  L4  L5  L6
 
-        let leaf_0 = leaf_sum(FEE, &data[0]);
-        let leaf_1 = leaf_sum(FEE, &data[1]);
-        let leaf_2 = leaf_sum(FEE, &data[2]);
-        let leaf_3 = leaf_sum(FEE, &data[3]);
-        let leaf_4 = leaf_sum(FEE, &data[4]);
-        let leaf_5 = leaf_sum(FEE, &data[5]);
-        let leaf_6 = leaf_sum(FEE, &data[6]);
+        let leaf_0 = leaf_sum(FEE, data[0]);
+        let leaf_1 = leaf_sum(FEE, data[1]);
+        let leaf_2 = leaf_sum(FEE, data[2]);
+        let leaf_3 = leaf_sum(FEE, data[3]);
+        let leaf_4 = leaf_sum(FEE, data[4]);
+        let leaf_5 = leaf_sum(FEE, data[5]);
+        let leaf_6 = leaf_sum(FEE, data[6]);
 
         let node_0 = node_sum(FEE * 1, &leaf_0, FEE * 1, &leaf_1);
         let node_1 = node_sum(FEE * 1, &leaf_2, FEE * 1, &leaf_3);

--- a/src/sum/node.rs
+++ b/src/sum/node.rs
@@ -33,8 +33,8 @@ impl Node {
             height,
             hash: node_sum(lhs_fee, lhs_key, rhs_fee, rhs_key),
             fee: lhs_fee + rhs_fee,
-            left_child_key: Some(lhs_key.clone()),
-            right_child_key: Some(rhs_key.clone()),
+            left_child_key: Some(*lhs_key),
+            right_child_key: Some(*rhs_key),
         }
     }
 
@@ -51,11 +51,11 @@ impl Node {
     }
 
     pub fn left_child_key(&self) -> Option<Bytes32> {
-        self.left_child_key.clone()
+        self.left_child_key
     }
 
     pub fn right_child_key(&self) -> Option<Bytes32> {
-        self.right_child_key.clone()
+        self.right_child_key
     }
 
     pub fn is_leaf(&self) -> bool {

--- a/test-helpers/src/binary/merkle_tree.rs
+++ b/test-helpers/src/binary/merkle_tree.rs
@@ -155,7 +155,7 @@ mod test {
         mt.push(&data);
         let root = mt.root();
 
-        let expected = leaf_sum(&data);
+        let expected = leaf_sum(data);
         assert_eq!(root, expected);
     }
 
@@ -176,10 +176,10 @@ mod test {
         //  /  \    /  \
         // L1  L2  L3  L4
 
-        let leaf_1 = leaf_sum(&data[0]);
-        let leaf_2 = leaf_sum(&data[1]);
-        let leaf_3 = leaf_sum(&data[2]);
-        let leaf_4 = leaf_sum(&data[3]);
+        let leaf_1 = leaf_sum(data[0]);
+        let leaf_2 = leaf_sum(data[1]);
+        let leaf_3 = leaf_sum(data[2]);
+        let leaf_4 = leaf_sum(data[3]);
 
         let node_1 = node_sum(&leaf_1, &leaf_2);
         let node_2 = node_sum(&leaf_3, &leaf_4);
@@ -208,11 +208,11 @@ mod test {
         //  /  \    /  \   \
         // L1  L2  L3  L4  L5
 
-        let leaf_1 = leaf_sum(&data[0]);
-        let leaf_2 = leaf_sum(&data[1]);
-        let leaf_3 = leaf_sum(&data[2]);
-        let leaf_4 = leaf_sum(&data[3]);
-        let leaf_5 = leaf_sum(&data[4]);
+        let leaf_1 = leaf_sum(data[0]);
+        let leaf_2 = leaf_sum(data[1]);
+        let leaf_3 = leaf_sum(data[2]);
+        let leaf_4 = leaf_sum(data[3]);
+        let leaf_5 = leaf_sum(data[4]);
 
         let node_1 = node_sum(&leaf_1, &leaf_2);
         let node_2 = node_sum(&leaf_3, &leaf_4);
@@ -243,13 +243,13 @@ mod test {
         //  /  \    /  \    /  \   \
         // L1  L2  L3  L4  L5  L6  L7
 
-        let leaf_1 = leaf_sum(&data[0]);
-        let leaf_2 = leaf_sum(&data[1]);
-        let leaf_3 = leaf_sum(&data[2]);
-        let leaf_4 = leaf_sum(&data[3]);
-        let leaf_5 = leaf_sum(&data[4]);
-        let leaf_6 = leaf_sum(&data[5]);
-        let leaf_7 = leaf_sum(&data[6]);
+        let leaf_1 = leaf_sum(data[0]);
+        let leaf_2 = leaf_sum(data[1]);
+        let leaf_3 = leaf_sum(data[2]);
+        let leaf_4 = leaf_sum(data[3]);
+        let leaf_5 = leaf_sum(data[4]);
+        let leaf_6 = leaf_sum(data[5]);
+        let leaf_7 = leaf_sum(data[6]);
 
         let node_1 = node_sum(&leaf_1, &leaf_2);
         let node_2 = node_sum(&leaf_3, &leaf_4);
@@ -295,10 +295,10 @@ mod test {
         //  /  \    /  \
         // L1  L2  L3  L4
 
-        let leaf_1 = leaf_sum(&data[0]);
-        let leaf_2 = leaf_sum(&data[1]);
-        let leaf_3 = leaf_sum(&data[2]);
-        let leaf_4 = leaf_sum(&data[3]);
+        let leaf_1 = leaf_sum(data[0]);
+        let leaf_2 = leaf_sum(data[1]);
+        let leaf_3 = leaf_sum(data[2]);
+        let leaf_4 = leaf_sum(data[3]);
 
         let node_1 = node_sum(&leaf_1, &leaf_2);
         let node_2 = node_sum(&leaf_3, &leaf_4);
@@ -332,11 +332,11 @@ mod test {
         //  /  \    /  \   \
         // L1  L2  L3  L4  L5
 
-        let leaf_1 = leaf_sum(&data[0]);
-        let leaf_2 = leaf_sum(&data[1]);
-        let leaf_3 = leaf_sum(&data[2]);
-        let leaf_4 = leaf_sum(&data[3]);
-        let leaf_5 = leaf_sum(&data[4]);
+        let leaf_1 = leaf_sum(data[0]);
+        let leaf_2 = leaf_sum(data[1]);
+        let leaf_3 = leaf_sum(data[2]);
+        let leaf_4 = leaf_sum(data[3]);
+        let leaf_5 = leaf_sum(data[4]);
 
         let node_1 = node_sum(&leaf_1, &leaf_2);
         let node_2 = node_sum(&leaf_3, &leaf_4);
@@ -373,11 +373,11 @@ mod test {
         //  /  \    /  \   \
         // L1  L2  L3  L4  L5
 
-        let leaf_1 = leaf_sum(&data[0]);
-        let leaf_2 = leaf_sum(&data[1]);
-        let leaf_3 = leaf_sum(&data[2]);
-        let leaf_4 = leaf_sum(&data[3]);
-        let leaf_5 = leaf_sum(&data[4]);
+        let leaf_1 = leaf_sum(data[0]);
+        let leaf_2 = leaf_sum(data[1]);
+        let leaf_3 = leaf_sum(data[2]);
+        let leaf_4 = leaf_sum(data[3]);
+        let leaf_5 = leaf_sum(data[4]);
 
         let node_1 = node_sum(&leaf_1, &leaf_2);
         let node_2 = node_sum(&leaf_3, &leaf_4);

--- a/tests-data/tests-data.rs
+++ b/tests-data/tests-data.rs
@@ -43,7 +43,7 @@ enum Encoding {
 }
 
 impl EncodedValue {
-    fn to_bytes(self) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    fn into_bytes(self) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         match self.encoding_type()? {
             Encoding::Hex => Ok(hex::decode(self.value).unwrap()),
             Encoding::Utf8 => Ok(self.value.into_bytes()),
@@ -80,15 +80,15 @@ impl Step {
     pub fn execute(self, tree: &mut MerkleTree) -> Result<(), Box<dyn std::error::Error>> {
         match self.action_type()? {
             Action::Update(encoded_key, encoded_data) => {
-                let key_bytes = encoded_key.to_bytes()?;
+                let key_bytes = encoded_key.into_bytes()?;
                 let key = &key_bytes.try_into().unwrap();
-                let data_bytes = encoded_data.to_bytes()?;
+                let data_bytes = encoded_data.into_bytes()?;
                 let data: &[u8] = &data_bytes;
                 tree.update(key, data).unwrap();
                 Ok(())
             }
             Action::Delete(encoded_key) => {
-                let key_bytes = encoded_key.to_bytes()?;
+                let key_bytes = encoded_key.into_bytes()?;
                 let key = &key_bytes.try_into().unwrap();
                 tree.delete(key).unwrap();
                 Ok(())
@@ -134,7 +134,7 @@ impl Test {
         }
 
         let root = tree.root();
-        let expected_root: Bytes32 = self.expected_root.to_bytes()?.try_into().unwrap();
+        let expected_root: Bytes32 = self.expected_root.into_bytes()?.try_into().unwrap();
 
         assert_eq!(root, expected_root);
 


### PR DESCRIPTION
Resolving `cargo clippy` lints.

Added two exceptions used only in tests:
  * `clippy::bool_assert_compariso` for `assert_eq!(Position(0).is_leaf(), true);`
  * `clippy::identity_op` for `FEE * 1` as it gives better clarity to have that number.

and we probably need to add `clippy` to ci: https://github.com/FuelLabs/fuel-merkle/issues/102