### PR TITLE
Feat: Implement Default for in-memory Merkle trees

### DIFF
--- a/src/binary/in_memory.rs
+++ b/src/binary/in_memory.rs
@@ -29,13 +29,11 @@ impl MerkleTree {
     }
 }
 
-
 impl Default for MerkleTree {
     fn default() -> Self {
         Self::new()
     }
 }
-
 
 #[cfg(test)]
 mod test {

--- a/src/sparse/in_memory.rs
+++ b/src/sparse/in_memory.rs
@@ -29,13 +29,11 @@ impl MerkleTree {
     }
 }
 
-
 impl Default for MerkleTree {
     fn default() -> Self {
         Self::new()
     }
 }
-
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
Related issues:
- Progress on https://github.com/FuelLabs/fuel-merkle/issues/102

Clippy suggests adding defaults to the in-memory SMTs since they have default constructors. 



