### PR TITLE
Add clippy job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all --verbose -- -D warnings
+          args: --all-targets --all-features --verbose -- -D warnings
 
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,73 +12,118 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  check-formatting:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    - name: Install toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
 
-    # Using thumbv6m-none-eabi as ARMv6-M arbitrary common choice for a bare-minimum target.
-    # More info: https://docs.rs/cortex-m-rt/latest/cortex_m_rt/
-    #
-    # Can be replaced by other targets that guarantee bare-minimum no-std
-    - name: Install toolchain no-std
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: thumbv6m-none-eabi
-        override: true
+      - name: Install rustfmt
+        run: rustup component add rustfmt
 
-    - name: Install rustfmt
-      run: rustup component add rustfmt
+      - name: Check formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all --verbose -- --check
 
-    - name: Check formatting
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all --verbose -- --check
+  check-clippy:
+    runs-on: ubuntu-latest
 
-    - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --verbose
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --verbose
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Check Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --verbose -- -D warnings
 
-    - name: Run helper tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --verbose --package fuel-merkle-test-helpers
+  build-and-test:
+    runs-on: ubuntu-latest
 
-    - name: Build no-std
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --verbose --target thumbv6m-none-eabi --no-default-features
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    - name: Run tests no-std
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --verbose --no-default-features
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose
+
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose
+
+      - name: Run helper tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --package fuel-merkle-test-helpers
+
+  build-and-test-no-std:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+        # Using thumbv6m-none-eabi as ARMv6-M arbitrary common choice for a bare-minimum target.
+        # More info: https://docs.rs/cortex-m-rt/latest/cortex_m_rt/
+        #
+        # Can be replaced by other targets that guarantee bare-minimum no-std
+      - name: Install toolchain no-std
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: thumbv6m-none-eabi
+          override: true
+
+      - name: Build no-std
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose --target thumbv6m-none-eabi --no-default-features
+
+      - name: Run tests no-std
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --no-default-features
 
   publish:
+    needs: [
+      check-formatting,
+      check-clippy,
+      build-and-test,
+      build-and-test-no-std
+    ]
     # Only do this job if publishing a release
-    needs: build
     if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,12 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+
       - name: Check Clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --verbose -- -D warnings
+          args: --all --verbose -- -D warnings
 
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Related issues:
- Closes https://github.com/FuelLabs/fuel-merkle/issues/102

This PR updates the github CI script to include a job for running Clippy. 

The existing `build` job is now broken up into multiple jobs to better communicate their purpose:
- `check-formatting`
- `check-clippy`
- `build-and-test`
- `build-and-test-no-std`

Finally, the `publish` job now depends on the success of all the jobs prior.

This PR needs admin assistance to update the protected branch rules for master to account for the new CI job names - cc: @adlerjohn 
