### PR TITLE
Use `check` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,13 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Build
+      - name: Check
         uses: actions-rs/cargo@v1
         with:
-          command: build
+          command: check
           args: --verbose
+        env:
+          RUSTFLAGS: '-D warnings'
 
       - name: Run tests
         uses: actions-rs/cargo@v1
@@ -105,11 +107,13 @@ jobs:
           target: thumbv6m-none-eabi
           override: true
 
-      - name: Build no-std
+      - name: Check no-std
         uses: actions-rs/cargo@v1
         with:
-          command: build
+          command: check
           args: --verbose --target thumbv6m-none-eabi --no-default-features
+        env:
+          RUSTFLAGS: '-D warnings'
 
       - name: Run tests no-std
         uses: actions-rs/cargo@v1

--- a/src/binary/in_memory.rs
+++ b/src/binary/in_memory.rs
@@ -55,7 +55,7 @@ mod test {
 
         let data = &TEST_DATA[0..1]; // 1 leaf
         for datum in data.iter() {
-            let _ = tree.push(datum);
+            tree.push(datum);
         }
 
         let leaf_0 = leaf_sum(data[0]);
@@ -70,7 +70,7 @@ mod test {
 
         let data = &TEST_DATA[0..7]; // 7 leaves
         for datum in data.iter() {
-            let _ = tree.push(datum);
+            tree.push(datum);
         }
 
         //               07
@@ -121,7 +121,7 @@ mod test {
 
         let data = &TEST_DATA[0..5]; // 5 leaves
         for datum in data.iter() {
-            let _ = tree.push(datum);
+            tree.push(datum);
         }
 
         let proof = tree.prove(10);
@@ -134,7 +134,7 @@ mod test {
 
         let data = &TEST_DATA[0..1]; // 1 leaf
         for datum in data.iter() {
-            let _ = tree.push(datum);
+            tree.push(datum);
         }
 
         let leaf_0 = leaf_sum(data[0]);
@@ -155,7 +155,7 @@ mod test {
 
         let data = &TEST_DATA[0..7]; // 7 leaves
         for datum in data.iter() {
-            let _ = tree.push(datum);
+            tree.push(datum);
         }
 
         //               07

--- a/tests-data/tests-data.rs
+++ b/tests-data/tests-data.rs
@@ -123,7 +123,7 @@ struct InMemoryMerkleTreeTestAdaptor {
     tree: Box<in_memory::MerkleTree>,
 }
 
-impl<'a> MerkleTreeTestAdaptor for InMemoryMerkleTreeTestAdaptor {
+impl MerkleTreeTestAdaptor for InMemoryMerkleTreeTestAdaptor {
     fn update(&mut self, key: &Bytes32, data: &[u8]) {
         self.tree.as_mut().update(key, data)
     }


### PR DESCRIPTION
Related issues:
- Closes #107 
- Closes #45 

This PR accomplishes the following:
- During CI, use the `cargo check` command over `cargo build`. See [cargo check docs](https://doc.rust-lang.org/cargo/commands/cargo-check.html) for details.
- During CI, `cargo check` will fail if any compiler warnings are present in the code. This is accomplished by setting the environment variable `RUSTFLAGS="-D warnings"`
- Fixes some warnings discovered by Clippy