### PR TITLE
debt: Remove first leaf from BMT proof set

### DIFF
--- a/src/binary/in_memory.rs
+++ b/src/binary/in_memory.rs
@@ -128,7 +128,7 @@ mod test {
     }
 
     #[test]
-    fn prove_returns_the_merkle_root_and_proof_set_for_1_leaf() {
+    fn prove_returns_the_merkle_root_and_empty_proof_set_for_1_leaf() {
         let mut tree = MerkleTree::new();
 
         let data = &TEST_DATA[0..1]; // 1 leaf
@@ -144,7 +144,7 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, leaf_0);
-            assert_eq!(set[0], leaf_0);
+            assert_eq!(set, ProofSet::default());
         }
     }
 
@@ -193,10 +193,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_0);
-            assert_eq!(set[1], leaf_1);
-            assert_eq!(set[2], node_5);
-            assert_eq!(set[3], node_11);
+            assert_eq!(set[0], leaf_1);
+            assert_eq!(set[1], node_5);
+            assert_eq!(set[2], node_11);
         }
         {
             let proof = tree.prove(1).unwrap();
@@ -204,10 +203,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_1);
-            assert_eq!(set[1], leaf_0);
-            assert_eq!(set[2], node_5);
-            assert_eq!(set[3], node_11);
+            assert_eq!(set[0], leaf_0);
+            assert_eq!(set[1], node_5);
+            assert_eq!(set[2], node_11);
         }
         {
             let proof = tree.prove(2).unwrap();
@@ -215,10 +213,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_2);
-            assert_eq!(set[1], leaf_3);
-            assert_eq!(set[2], node_1);
-            assert_eq!(set[3], node_11);
+            assert_eq!(set[0], leaf_3);
+            assert_eq!(set[1], node_1);
+            assert_eq!(set[2], node_11);
         }
         {
             let proof = tree.prove(3).unwrap();
@@ -226,10 +223,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_3);
-            assert_eq!(set[1], leaf_2);
-            assert_eq!(set[2], node_1);
-            assert_eq!(set[3], node_11);
+            assert_eq!(set[0], leaf_2);
+            assert_eq!(set[1], node_1);
+            assert_eq!(set[2], node_11);
         }
         {
             let proof = tree.prove(4).unwrap();
@@ -237,10 +233,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_4);
-            assert_eq!(set[1], leaf_5);
-            assert_eq!(set[2], leaf_6);
-            assert_eq!(set[3], node_3);
+            assert_eq!(set[0], leaf_5);
+            assert_eq!(set[1], leaf_6);
+            assert_eq!(set[2], node_3);
         }
         {
             let proof = tree.prove(5).unwrap();
@@ -248,10 +243,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_5);
-            assert_eq!(set[1], leaf_4);
-            assert_eq!(set[2], leaf_6);
-            assert_eq!(set[3], node_3);
+            assert_eq!(set[0], leaf_4);
+            assert_eq!(set[1], leaf_6);
+            assert_eq!(set[2], node_3);
         }
         {
             let proof = tree.prove(6).unwrap();
@@ -259,9 +253,8 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_6);
-            assert_eq!(set[1], node_9);
-            assert_eq!(set[2], node_3);
+            assert_eq!(set[0], node_9);
+            assert_eq!(set[1], node_3);
         }
     }
 }

--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -98,9 +98,6 @@ where
         let root_node = self.root_node()?.unwrap();
         let root_position = root_node.position();
         let leaf_position = Position::from_leaf_index(proof_index);
-        let leaf_node = self.storage.get(&leaf_position.in_order_index())?.unwrap();
-        proof_set.push(*leaf_node.hash());
-
         let (_, mut side_positions): (Vec<_>, Vec<_>) = root_position
             .path(&leaf_position, self.leaves_count)
             .iter()
@@ -207,7 +204,7 @@ where
 mod test {
     use super::{MerkleTree, NodesTable};
     use crate::binary::{empty_sum, leaf_sum, node_sum};
-    use crate::common::StorageMap;
+    use crate::common::{ProofSet, StorageMap};
     use fuel_merkle_test_helpers::TEST_DATA;
     use fuel_storage::StorageInspect;
 
@@ -407,7 +404,7 @@ mod test {
     }
 
     #[test]
-    fn prove_returns_the_merkle_root_and_proof_set_for_1_leaf() {
+    fn prove_returns_the_merkle_root_and_empty_proof_set_for_1_leaf() {
         let mut storage_map = StorageMap::<NodesTable>::new();
         let mut tree = MerkleTree::new(&mut storage_map);
 
@@ -424,7 +421,7 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, leaf_0);
-            assert_eq!(set[0], leaf_0);
+            assert_eq!(set, ProofSet::default());
         }
     }
 
@@ -461,9 +458,8 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_3);
-            assert_eq!(set[0], leaf_0);
-            assert_eq!(set[1], leaf_1);
-            assert_eq!(set[2], node_5);
+            assert_eq!(set[0], leaf_1);
+            assert_eq!(set[1], node_5);
         }
         {
             let proof = tree.prove(1).unwrap();
@@ -471,9 +467,8 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_3);
-            assert_eq!(set[0], leaf_1);
-            assert_eq!(set[1], leaf_0);
-            assert_eq!(set[2], node_5);
+            assert_eq!(set[0], leaf_0);
+            assert_eq!(set[1], node_5);
         }
         {
             let proof = tree.prove(2).unwrap();
@@ -481,9 +476,8 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_3);
-            assert_eq!(set[0], leaf_2);
-            assert_eq!(set[1], leaf_3);
-            assert_eq!(set[2], node_1);
+            assert_eq!(set[0], leaf_3);
+            assert_eq!(set[1], node_1);
         }
         {
             let proof = tree.prove(3).unwrap();
@@ -491,9 +485,8 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_3);
-            assert_eq!(set[0], leaf_3);
-            assert_eq!(set[1], leaf_2);
-            assert_eq!(set[2], node_1);
+            assert_eq!(set[0], leaf_2);
+            assert_eq!(set[1], node_1);
         }
     }
 
@@ -535,10 +528,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_0);
-            assert_eq!(set[1], leaf_1);
-            assert_eq!(set[2], node_5);
-            assert_eq!(set[3], leaf_4);
+            assert_eq!(set[0], leaf_1);
+            assert_eq!(set[1], node_5);
+            assert_eq!(set[2], leaf_4);
         }
         {
             let proof = tree.prove(1).unwrap();
@@ -546,10 +538,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_1);
-            assert_eq!(set[1], leaf_0);
-            assert_eq!(set[2], node_5);
-            assert_eq!(set[3], leaf_4);
+            assert_eq!(set[0], leaf_0);
+            assert_eq!(set[1], node_5);
+            assert_eq!(set[2], leaf_4);
         }
         {
             let proof = tree.prove(2).unwrap();
@@ -557,10 +548,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_2);
-            assert_eq!(set[1], leaf_3);
-            assert_eq!(set[2], node_1);
-            assert_eq!(set[3], leaf_4);
+            assert_eq!(set[0], leaf_3);
+            assert_eq!(set[1], node_1);
+            assert_eq!(set[2], leaf_4);
         }
         {
             let proof = tree.prove(3).unwrap();
@@ -568,10 +558,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_3);
-            assert_eq!(set[1], leaf_2);
-            assert_eq!(set[2], node_1);
-            assert_eq!(set[3], leaf_4);
+            assert_eq!(set[0], leaf_2);
+            assert_eq!(set[1], node_1);
+            assert_eq!(set[2], leaf_4);
         }
         {
             let proof = tree.prove(4).unwrap();
@@ -579,8 +568,7 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_4);
-            assert_eq!(set[1], node_3);
+            assert_eq!(set[0], node_3);
         }
     }
 
@@ -630,10 +618,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_0);
-            assert_eq!(set[1], leaf_1);
-            assert_eq!(set[2], node_5);
-            assert_eq!(set[3], node_11);
+            assert_eq!(set[0], leaf_1);
+            assert_eq!(set[1], node_5);
+            assert_eq!(set[2], node_11);
         }
         {
             let proof = tree.prove(1).unwrap();
@@ -641,10 +628,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_1);
-            assert_eq!(set[1], leaf_0);
-            assert_eq!(set[2], node_5);
-            assert_eq!(set[3], node_11);
+            assert_eq!(set[0], leaf_0);
+            assert_eq!(set[1], node_5);
+            assert_eq!(set[2], node_11);
         }
         {
             let proof = tree.prove(2).unwrap();
@@ -652,10 +638,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_2);
-            assert_eq!(set[1], leaf_3);
-            assert_eq!(set[2], node_1);
-            assert_eq!(set[3], node_11);
+            assert_eq!(set[0], leaf_3);
+            assert_eq!(set[1], node_1);
+            assert_eq!(set[2], node_11);
         }
         {
             let proof = tree.prove(3).unwrap();
@@ -663,10 +648,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_3);
-            assert_eq!(set[1], leaf_2);
-            assert_eq!(set[2], node_1);
-            assert_eq!(set[3], node_11);
+            assert_eq!(set[0], leaf_2);
+            assert_eq!(set[1], node_1);
+            assert_eq!(set[2], node_11);
         }
         {
             let proof = tree.prove(4).unwrap();
@@ -674,10 +658,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_4);
-            assert_eq!(set[1], leaf_5);
-            assert_eq!(set[2], leaf_6);
-            assert_eq!(set[3], node_3);
+            assert_eq!(set[0], leaf_5);
+            assert_eq!(set[1], leaf_6);
+            assert_eq!(set[2], node_3);
         }
         {
             let proof = tree.prove(5).unwrap();
@@ -685,10 +668,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_5);
-            assert_eq!(set[1], leaf_4);
-            assert_eq!(set[2], leaf_6);
-            assert_eq!(set[3], node_3);
+            assert_eq!(set[0], leaf_4);
+            assert_eq!(set[1], leaf_6);
+            assert_eq!(set[2], node_3);
         }
         {
             let proof = tree.prove(6).unwrap();
@@ -696,9 +678,8 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_6);
-            assert_eq!(set[1], node_9);
-            assert_eq!(set[2], node_3);
+            assert_eq!(set[0], node_9);
+            assert_eq!(set[1], node_3);
         }
     }
 }


### PR DESCRIPTION
Related PRs:
- Closes #14

As per the binary Merkle tree specification we use, defined by [RFC 6962](https://www.rfc-editor.org/rfc/rfc6962), the binary Merkle tree proof set does not include the leaf for which we are proving. Therefore, this PR removes that leaf from the generated proof set. 

Note: We do not currently implement proofs for BMSTs so this PR does not modify any behaviour in that area.