### PR TITLE
Revert #115

### DIFF
--- a/src/binary/in_memory.rs
+++ b/src/binary/in_memory.rs
@@ -128,7 +128,7 @@ mod test {
     }
 
     #[test]
-    fn prove_returns_the_merkle_root_and_empty_proof_set_for_1_leaf() {
+    fn prove_returns_the_merkle_root_and_proof_set_for_1_leaf() {
         let mut tree = MerkleTree::new();
 
         let data = &TEST_DATA[0..1]; // 1 leaf
@@ -144,7 +144,7 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, leaf_0);
-            assert_eq!(set, ProofSet::default());
+            assert_eq!(set[0], leaf_0);
         }
     }
 
@@ -193,9 +193,10 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_1);
-            assert_eq!(set[1], node_5);
-            assert_eq!(set[2], node_11);
+            assert_eq!(set[0], leaf_0);
+            assert_eq!(set[1], leaf_1);
+            assert_eq!(set[2], node_5);
+            assert_eq!(set[3], node_11);
         }
         {
             let proof = tree.prove(1).unwrap();
@@ -203,9 +204,10 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_0);
-            assert_eq!(set[1], node_5);
-            assert_eq!(set[2], node_11);
+            assert_eq!(set[0], leaf_1);
+            assert_eq!(set[1], leaf_0);
+            assert_eq!(set[2], node_5);
+            assert_eq!(set[3], node_11);
         }
         {
             let proof = tree.prove(2).unwrap();
@@ -213,9 +215,10 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_3);
-            assert_eq!(set[1], node_1);
-            assert_eq!(set[2], node_11);
+            assert_eq!(set[0], leaf_2);
+            assert_eq!(set[1], leaf_3);
+            assert_eq!(set[2], node_1);
+            assert_eq!(set[3], node_11);
         }
         {
             let proof = tree.prove(3).unwrap();
@@ -223,9 +226,10 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_2);
-            assert_eq!(set[1], node_1);
-            assert_eq!(set[2], node_11);
+            assert_eq!(set[0], leaf_3);
+            assert_eq!(set[1], leaf_2);
+            assert_eq!(set[2], node_1);
+            assert_eq!(set[3], node_11);
         }
         {
             let proof = tree.prove(4).unwrap();
@@ -233,9 +237,10 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_5);
-            assert_eq!(set[1], leaf_6);
-            assert_eq!(set[2], node_3);
+            assert_eq!(set[0], leaf_4);
+            assert_eq!(set[1], leaf_5);
+            assert_eq!(set[2], leaf_6);
+            assert_eq!(set[3], node_3);
         }
         {
             let proof = tree.prove(5).unwrap();
@@ -243,9 +248,10 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_4);
-            assert_eq!(set[1], leaf_6);
-            assert_eq!(set[2], node_3);
+            assert_eq!(set[0], leaf_5);
+            assert_eq!(set[1], leaf_4);
+            assert_eq!(set[2], leaf_6);
+            assert_eq!(set[3], node_3);
         }
         {
             let proof = tree.prove(6).unwrap();
@@ -253,8 +259,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], node_9);
-            assert_eq!(set[1], node_3);
+            assert_eq!(set[0], leaf_6);
+            assert_eq!(set[1], node_9);
+            assert_eq!(set[2], node_3);
         }
     }
 }

--- a/src/binary/merkle_tree.rs
+++ b/src/binary/merkle_tree.rs
@@ -98,6 +98,9 @@ where
         let root_node = self.root_node()?.unwrap();
         let root_position = root_node.position();
         let leaf_position = Position::from_leaf_index(proof_index);
+        let leaf_node = self.storage.get(&leaf_position.in_order_index())?.unwrap();
+        proof_set.push(*leaf_node.hash());
+
         let (_, mut side_positions): (Vec<_>, Vec<_>) = root_position
             .path(&leaf_position, self.leaves_count)
             .iter()
@@ -204,7 +207,7 @@ where
 mod test {
     use super::{MerkleTree, NodesTable};
     use crate::binary::{empty_sum, leaf_sum, node_sum};
-    use crate::common::{ProofSet, StorageMap};
+    use crate::common::StorageMap;
     use fuel_merkle_test_helpers::TEST_DATA;
     use fuel_storage::StorageInspect;
 
@@ -404,7 +407,7 @@ mod test {
     }
 
     #[test]
-    fn prove_returns_the_merkle_root_and_empty_proof_set_for_1_leaf() {
+    fn prove_returns_the_merkle_root_and_proof_set_for_1_leaf() {
         let mut storage_map = StorageMap::<NodesTable>::new();
         let mut tree = MerkleTree::new(&mut storage_map);
 
@@ -421,7 +424,7 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, leaf_0);
-            assert_eq!(set, ProofSet::default());
+            assert_eq!(set[0], leaf_0);
         }
     }
 
@@ -458,8 +461,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_3);
-            assert_eq!(set[0], leaf_1);
-            assert_eq!(set[1], node_5);
+            assert_eq!(set[0], leaf_0);
+            assert_eq!(set[1], leaf_1);
+            assert_eq!(set[2], node_5);
         }
         {
             let proof = tree.prove(1).unwrap();
@@ -467,8 +471,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_3);
-            assert_eq!(set[0], leaf_0);
-            assert_eq!(set[1], node_5);
+            assert_eq!(set[0], leaf_1);
+            assert_eq!(set[1], leaf_0);
+            assert_eq!(set[2], node_5);
         }
         {
             let proof = tree.prove(2).unwrap();
@@ -476,8 +481,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_3);
-            assert_eq!(set[0], leaf_3);
-            assert_eq!(set[1], node_1);
+            assert_eq!(set[0], leaf_2);
+            assert_eq!(set[1], leaf_3);
+            assert_eq!(set[2], node_1);
         }
         {
             let proof = tree.prove(3).unwrap();
@@ -485,8 +491,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_3);
-            assert_eq!(set[0], leaf_2);
-            assert_eq!(set[1], node_1);
+            assert_eq!(set[0], leaf_3);
+            assert_eq!(set[1], leaf_2);
+            assert_eq!(set[2], node_1);
         }
     }
 
@@ -528,9 +535,10 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_1);
-            assert_eq!(set[1], node_5);
-            assert_eq!(set[2], leaf_4);
+            assert_eq!(set[0], leaf_0);
+            assert_eq!(set[1], leaf_1);
+            assert_eq!(set[2], node_5);
+            assert_eq!(set[3], leaf_4);
         }
         {
             let proof = tree.prove(1).unwrap();
@@ -538,9 +546,10 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_0);
-            assert_eq!(set[1], node_5);
-            assert_eq!(set[2], leaf_4);
+            assert_eq!(set[0], leaf_1);
+            assert_eq!(set[1], leaf_0);
+            assert_eq!(set[2], node_5);
+            assert_eq!(set[3], leaf_4);
         }
         {
             let proof = tree.prove(2).unwrap();
@@ -548,9 +557,10 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_3);
-            assert_eq!(set[1], node_1);
-            assert_eq!(set[2], leaf_4);
+            assert_eq!(set[0], leaf_2);
+            assert_eq!(set[1], leaf_3);
+            assert_eq!(set[2], node_1);
+            assert_eq!(set[3], leaf_4);
         }
         {
             let proof = tree.prove(3).unwrap();
@@ -558,9 +568,10 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_2);
-            assert_eq!(set[1], node_1);
-            assert_eq!(set[2], leaf_4);
+            assert_eq!(set[0], leaf_3);
+            assert_eq!(set[1], leaf_2);
+            assert_eq!(set[2], node_1);
+            assert_eq!(set[3], leaf_4);
         }
         {
             let proof = tree.prove(4).unwrap();
@@ -568,7 +579,8 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], node_3);
+            assert_eq!(set[0], leaf_4);
+            assert_eq!(set[1], node_3);
         }
     }
 
@@ -618,9 +630,10 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_1);
-            assert_eq!(set[1], node_5);
-            assert_eq!(set[2], node_11);
+            assert_eq!(set[0], leaf_0);
+            assert_eq!(set[1], leaf_1);
+            assert_eq!(set[2], node_5);
+            assert_eq!(set[3], node_11);
         }
         {
             let proof = tree.prove(1).unwrap();
@@ -628,9 +641,10 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_0);
-            assert_eq!(set[1], node_5);
-            assert_eq!(set[2], node_11);
+            assert_eq!(set[0], leaf_1);
+            assert_eq!(set[1], leaf_0);
+            assert_eq!(set[2], node_5);
+            assert_eq!(set[3], node_11);
         }
         {
             let proof = tree.prove(2).unwrap();
@@ -638,9 +652,10 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_3);
-            assert_eq!(set[1], node_1);
-            assert_eq!(set[2], node_11);
+            assert_eq!(set[0], leaf_2);
+            assert_eq!(set[1], leaf_3);
+            assert_eq!(set[2], node_1);
+            assert_eq!(set[3], node_11);
         }
         {
             let proof = tree.prove(3).unwrap();
@@ -648,9 +663,10 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_2);
-            assert_eq!(set[1], node_1);
-            assert_eq!(set[2], node_11);
+            assert_eq!(set[0], leaf_3);
+            assert_eq!(set[1], leaf_2);
+            assert_eq!(set[2], node_1);
+            assert_eq!(set[3], node_11);
         }
         {
             let proof = tree.prove(4).unwrap();
@@ -658,9 +674,10 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_5);
-            assert_eq!(set[1], leaf_6);
-            assert_eq!(set[2], node_3);
+            assert_eq!(set[0], leaf_4);
+            assert_eq!(set[1], leaf_5);
+            assert_eq!(set[2], leaf_6);
+            assert_eq!(set[3], node_3);
         }
         {
             let proof = tree.prove(5).unwrap();
@@ -668,9 +685,10 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], leaf_4);
-            assert_eq!(set[1], leaf_6);
-            assert_eq!(set[2], node_3);
+            assert_eq!(set[0], leaf_5);
+            assert_eq!(set[1], leaf_4);
+            assert_eq!(set[2], leaf_6);
+            assert_eq!(set[3], node_3);
         }
         {
             let proof = tree.prove(6).unwrap();
@@ -678,8 +696,9 @@ mod test {
             let set = proof.1;
 
             assert_eq!(root, node_7);
-            assert_eq!(set[0], node_9);
-            assert_eq!(set[1], node_3);
+            assert_eq!(set[0], leaf_6);
+            assert_eq!(set[1], node_9);
+            assert_eq!(set[2], node_3);
         }
     }
 }


### PR DESCRIPTION
This reverts PR #115, commit bf201991ae06353259d980f2633ba764a17980f2.

It turns out that removing the first leaf from the BMT proof set makes it incompatible with the current implementation of proof verification in `test-helpers/src/binary/verify.rs`.  Proof sets without the first leaf (the leaf being proven) are incomplete; the first leaf is required in order to allow the proof set to be properly hashed together to form the root signature. 

The previous PR removed the first leaf from the public implementation of the proof sets. However, the reference implementation began to fail its verification test suite once I updated it to remove the first leaf from its proof sets. Therefore, I am reverting the change to remove the first leaf from the public implementation in order to maintain parity with the reference implementation.