### PR TITLE
Clippy and dependency upgrades

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = "Fuel Merkle tree libraries."
 [dependencies]
 digest = { version = "0.10", default-features = false }
 fuel-storage = "0.3"
-hashbrown = "0.12"
+hashbrown = "0.13"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 sha2 = { version = "0.10", default-features = false }
 thiserror = { version = "1.0", optional = true }
@@ -23,7 +23,7 @@ fuel-merkle-test-helpers = { path = "test-helpers" }
 hex = "0.4"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.8"
+serde_yaml = "0.9"
 thiserror = "1.0"
 
 [features]

--- a/src/binary/hash.rs
+++ b/src/binary/hash.rs
@@ -16,9 +16,9 @@ pub const fn empty_sum() -> &'static Bytes32 {
 pub fn node_sum(lhs_data: &[u8], rhs_data: &[u8]) -> Bytes32 {
     let mut hash = Hash::new();
 
-    hash.update(&[NODE]);
-    hash.update(&lhs_data);
-    hash.update(&rhs_data);
+    hash.update([NODE]);
+    hash.update(lhs_data);
+    hash.update(rhs_data);
 
     hash.finalize().into()
 }
@@ -28,8 +28,8 @@ pub fn node_sum(lhs_data: &[u8], rhs_data: &[u8]) -> Bytes32 {
 pub fn leaf_sum(data: &[u8]) -> Bytes32 {
     let mut hash = Hash::new();
 
-    hash.update(&[LEAF]);
-    hash.update(&data);
+    hash.update([LEAF]);
+    hash.update(data);
 
     hash.finalize().into()
 }

--- a/src/sparse/hash.rs
+++ b/src/sparse/hash.rs
@@ -13,6 +13,6 @@ pub fn zero_sum() -> &'static Bytes32 {
 
 pub fn sum(data: &[u8]) -> Bytes32 {
     let mut hash = Hash::new();
-    hash.update(&data);
+    hash.update(data);
     hash.finalize().try_into().unwrap()
 }

--- a/src/sum/hash.rs
+++ b/src/sum/hash.rs
@@ -13,11 +13,11 @@ pub const fn empty_sum() -> &'static Bytes32 {
 // MTH(D[n]) = Hash(0x01 || LHS fee || MTH(D[0:k]) || RHS fee || MTH(D[k:n])
 pub fn node_sum(lhs_fee: u64, lhs_data: &[u8], rhs_fee: u64, rhs_data: &[u8]) -> Bytes32 {
     let mut hash = Sha256::new();
-    hash.update(&[NODE]);
+    hash.update([NODE]);
     hash.update(lhs_fee.to_be_bytes());
-    hash.update(&lhs_data);
+    hash.update(lhs_data);
     hash.update(rhs_fee.to_be_bytes());
-    hash.update(&rhs_data);
+    hash.update(rhs_data);
     hash.finalize().try_into().unwrap()
 }
 
@@ -25,8 +25,8 @@ pub fn node_sum(lhs_fee: u64, lhs_data: &[u8], rhs_fee: u64, rhs_data: &[u8]) ->
 // MTH({d(0)}) = Hash(0x00 || fee || d(0))
 pub fn leaf_sum(fee: u64, data: &[u8]) -> Bytes32 {
     let mut hash = Sha256::new();
-    hash.update(&[LEAF]);
+    hash.update([LEAF]);
     hash.update(fee.to_be_bytes());
-    hash.update(&data);
+    hash.update(data);
     hash.finalize().try_into().unwrap()
 }

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2018"
 
 [dependencies]
-digest = "~0.9.0"
-sha2 = "~0.9.5"
+digest = "0.10"
+sha2 = "0.10"


### PR DESCRIPTION
Clippy errors are causing other PRs to fail CI.