### PR TITLE
refactor: Introduce `Path` trait and `Instruction`

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,5 +1,6 @@
 mod msb;
 mod node;
+mod path;
 mod path_iterator;
 mod position;
 mod position_path;
@@ -9,14 +10,15 @@ mod subtree;
 
 pub(crate) mod error;
 
-pub use msb::Msb;
 pub use node::{Node, ParentNode};
 pub use path_iterator::AsPathIterator;
 pub use position::Position;
 pub use storage_map::StorageMap;
 pub use subtree::Subtree;
 
+pub(crate) use msb::{Bit, Msb};
 pub(crate) use node::{ChildError, ChildResult};
+pub(crate) use path::{Instruction, Path};
 pub(crate) use position_path::PositionPath;
 pub(crate) use prefix::{Prefix, PrefixError};
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,5 @@
 mod msb;
 mod node;
-mod path;
 mod path_iterator;
 mod position;
 mod position_path;
@@ -9,6 +8,7 @@ mod storage_map;
 mod subtree;
 
 pub(crate) mod error;
+pub(crate) mod path;
 
 pub use node::{Node, ParentNode};
 pub use path_iterator::AsPathIterator;
@@ -18,7 +18,6 @@ pub use subtree::Subtree;
 
 pub(crate) use msb::{Bit, Msb};
 pub(crate) use node::{ChildError, ChildResult};
-pub(crate) use path::{Instruction, Path};
 pub(crate) use position_path::PositionPath;
 pub(crate) use prefix::{Prefix, PrefixError};
 

--- a/src/common/msb.rs
+++ b/src/common/msb.rs
@@ -11,8 +11,8 @@ trait GetBit {
 impl GetBit for u8 {
     fn get_bit(&self, bit_index: usize) -> Option<Bit> {
         if bit_index < 8 {
-            let shift = 1 << (7 - bit_index);
-            let bit = ((self & shift) != 0) as u8;
+            let mask = 1 << (7 - bit_index);
+            let bit = ((self & mask) != 0) as u8;
             match bit {
                 0 => Some(Bit::_0),
                 1 => Some(Bit::_1),

--- a/src/common/msb.rs
+++ b/src/common/msb.rs
@@ -12,11 +12,10 @@ impl GetBit for u8 {
     fn get_bit(&self, bit_index: usize) -> Option<Bit> {
         if bit_index < 8 {
             let mask = 1 << (7 - bit_index);
-            let bit = ((self & mask) != 0) as u8;
+            let bit = self & mask;
             match bit {
                 0 => Some(Bit::_0),
-                1 => Some(Bit::_1),
-                _ => unreachable!(),
+                _ => Some(Bit::_1),
             }
         } else {
             None

--- a/src/common/msb.rs
+++ b/src/common/msb.rs
@@ -1,13 +1,23 @@
+#[derive(Debug, Eq, PartialEq)]
+pub enum Bit {
+    _0 = 0,
+    _1 = 1,
+}
+
 trait GetBit {
-    fn get_bit(&self, bit_index: usize) -> Option<u8>;
+    fn get_bit(&self, bit_index: usize) -> Option<Bit>;
 }
 
 impl GetBit for u8 {
-    fn get_bit(&self, bit_index: usize) -> Option<u8> {
+    fn get_bit(&self, bit_index: usize) -> Option<Bit> {
         if bit_index < 8 {
             let shift = 1 << (7 - bit_index);
-            let bit = (self & shift) != 0;
-            Some(bit as u8)
+            let bit = ((self & shift) != 0) as u8;
+            match bit {
+                0 => Some(Bit::_0),
+                1 => Some(Bit::_1),
+                _ => unreachable!(),
+            }
         } else {
             None
         }
@@ -15,12 +25,12 @@ impl GetBit for u8 {
 }
 
 pub trait Msb {
-    fn get_bit_at_index_from_msb(&self, index: usize) -> Option<u8>;
+    fn get_bit_at_index_from_msb(&self, index: usize) -> Option<Bit>;
     fn common_prefix_count(&self, other: &Self) -> usize;
 }
 
 impl<const N: usize> Msb for [u8; N] {
-    fn get_bit_at_index_from_msb(&self, index: usize) -> Option<u8> {
+    fn get_bit_at_index_from_msb(&self, index: usize) -> Option<Bit> {
         // The byte that contains the bit
         let byte_index = index / 8;
         // The bit within the containing byte
@@ -58,7 +68,7 @@ mod test {
 
         let mut n = 0;
         for i in 0..NUM_BITS {
-            let bit = bytes.get_bit_at_index_from_msb(i).unwrap();
+            let bit = bytes.get_bit_at_index_from_msb(i).unwrap() as u8;
             let shift = bit << (NUM_BITS - 1 - i);
             n |= shift;
         }

--- a/src/common/path.rs
+++ b/src/common/path.rs
@@ -1,15 +1,15 @@
 use crate::common::{Bit, Msb};
 
 pub enum Instruction {
-    LEFT,
-    RIGHT,
+    Left,
+    Right,
 }
 
 impl From<Bit> for Instruction {
     fn from(bit: Bit) -> Self {
         match bit {
-            Bit::_0 => Instruction::LEFT,
-            Bit::_1 => Instruction::RIGHT,
+            Bit::_0 => Instruction::Left,
+            Bit::_1 => Instruction::Right,
         }
     }
 }

--- a/src/common/path.rs
+++ b/src/common/path.rs
@@ -1,0 +1,28 @@
+use crate::common::{Bit, Msb};
+
+pub enum Instruction {
+    LEFT,
+    RIGHT,
+}
+
+impl From<Bit> for Instruction {
+    fn from(bit: Bit) -> Self {
+        match bit {
+            Bit::_0 => Instruction::LEFT,
+            Bit::_1 => Instruction::RIGHT,
+        }
+    }
+}
+
+pub trait Path {
+    fn get_instruction(&self, index: usize) -> Option<Instruction>;
+}
+
+impl<T> Path for T
+where
+    T: Msb,
+{
+    fn get_instruction(&self, index: usize) -> Option<Instruction> {
+        self.get_bit_at_index_from_msb(index).map(Into::into)
+    }
+}

--- a/src/common/path.rs
+++ b/src/common/path.rs
@@ -18,11 +18,24 @@ pub trait Path {
     fn get_instruction(&self, index: usize) -> Option<Instruction>;
 }
 
+pub trait ComparablePath {
+    fn common_path_length(&self, other: &Self) -> usize;
+}
+
 impl<T> Path for T
 where
     T: Msb,
 {
     fn get_instruction(&self, index: usize) -> Option<Instruction> {
         self.get_bit_at_index_from_msb(index).map(Into::into)
+    }
+}
+
+impl<T> ComparablePath for T
+where
+    T: Msb,
+{
+    fn common_path_length(&self, other: &Self) -> usize {
+        self.common_prefix_count(other)
     }
 }

--- a/src/common/path_iterator.rs
+++ b/src/common/path_iterator.rs
@@ -158,8 +158,8 @@ where
                     let path = self.leaf.leaf_key();
                     let instruction = path.get_instruction(self.current_offset);
                     self.current = instruction.map(|instruction| match instruction {
-                        Instruction::LEFT => (path_node.left_child(), path_node.right_child()),
-                        Instruction::RIGHT => (path_node.right_child(), path_node.left_child()),
+                        Instruction::Left => (path_node.left_child(), path_node.right_child()),
+                        Instruction::Right => (path_node.right_child(), path_node.left_child()),
                     });
                     self.current_offset += 1;
                 }

--- a/src/common/path_iterator.rs
+++ b/src/common/path_iterator.rs
@@ -1,4 +1,7 @@
-use crate::common::{ChildResult, Instruction, ParentNode, Path};
+use crate::common::{
+    path::{Instruction, Path},
+    ChildResult, ParentNode,
+};
 
 /// # Path Iterator
 ///

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -1,7 +1,9 @@
 use crate::{
     common::{
-        error::DeserializeError, Bytes1, Bytes32, Bytes4, ChildError, ChildResult, Msb,
-        Node as NodeTrait, ParentNode as ParentNodeTrait, Path, Prefix,
+        error::DeserializeError,
+        path::{ComparablePath, Instruction, Path},
+        Bytes1, Bytes32, Bytes4, ChildError, ChildResult, Node as NodeTrait,
+        ParentNode as ParentNodeTrait, Prefix,
     },
     sparse::{hash::sum, merkle_tree::NodesTable, zero_sum},
 };
@@ -9,7 +11,6 @@ use crate::{
 // TODO: Return errors instead of `unwrap` during work with storage.
 use fuel_storage::StorageInspect;
 
-use crate::common::Instruction;
 use core::{cmp, fmt, mem::size_of, ops::Range};
 
 /// **Leaf buffer:**
@@ -107,7 +108,7 @@ impl Node {
         if self.is_placeholder() || other.is_placeholder() {
             0
         } else {
-            self.leaf_key().common_prefix_count(other.leaf_key())
+            self.leaf_key().common_path_length(other.leaf_key())
         }
     }
 

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::{
         error::DeserializeError, Bytes1, Bytes32, Bytes4, ChildError, ChildResult, Msb,
-        Node as NodeTrait, ParentNode as ParentNodeTrait, Prefix,
+        Node as NodeTrait, ParentNode as ParentNodeTrait, Path, Prefix,
     },
     sparse::{hash::sum, merkle_tree::NodesTable, zero_sum},
 };
@@ -9,9 +9,8 @@ use crate::{
 // TODO: Return errors instead of `unwrap` during work with storage.
 use fuel_storage::StorageInspect;
 
+use crate::common::Instruction;
 use core::{cmp, fmt, mem::size_of, ops::Range};
-
-const LEFT: u8 = 0;
 
 /// **Leaf buffer:**
 ///
@@ -65,7 +64,7 @@ impl Node {
         node
     }
 
-    pub fn create_node_on_path(path: &Bytes32, path_node: &Node, side_node: &Node) -> Self {
+    pub fn create_node_on_path(path: &dyn Path, path_node: &Node, side_node: &Node) -> Self {
         if path_node.is_leaf() && side_node.is_leaf() {
             // When joining two leaves, the joined node is found where the paths
             // of the two leaves diverge. The joined node may be a direct parent
@@ -74,10 +73,9 @@ impl Node {
             // N.B.: A leaf can be a placeholder.
             let parent_depth = path_node.common_path_length(side_node);
             let parent_height = (Node::max_height() - parent_depth) as u32;
-            if path.get_bit_at_index_from_msb(parent_depth).unwrap() == LEFT {
-                Node::create_node(path_node, side_node, parent_height)
-            } else {
-                Node::create_node(side_node, path_node, parent_height)
+            match path.get_instruction(parent_depth).unwrap() {
+                Instruction::LEFT => Node::create_node(path_node, side_node, parent_height),
+                Instruction::RIGHT => Node::create_node(side_node, path_node, parent_height),
             }
         } else {
             // When joining two nodes, or a node and a leaf, the joined node is
@@ -86,10 +84,9 @@ impl Node {
             // N.B.: A leaf can be a placeholder.
             let parent_height = cmp::max(path_node.height(), side_node.height()) + 1;
             let parent_depth = Node::max_height() - parent_height as usize;
-            if path.get_bit_at_index_from_msb(parent_depth).unwrap() == LEFT {
-                Node::create_node(path_node, side_node, parent_height)
-            } else {
-                Node::create_node(side_node, path_node, parent_height)
+            match path.get_instruction(parent_depth).unwrap() {
+                Instruction::LEFT => Node::create_node(path_node, side_node, parent_height),
+                Instruction::RIGHT => Node::create_node(side_node, path_node, parent_height),
             }
         }
     }

--- a/src/sparse/node.rs
+++ b/src/sparse/node.rs
@@ -75,8 +75,8 @@ impl Node {
             let parent_depth = path_node.common_path_length(side_node);
             let parent_height = (Node::max_height() - parent_depth) as u32;
             match path.get_instruction(parent_depth).unwrap() {
-                Instruction::LEFT => Node::create_node(path_node, side_node, parent_height),
-                Instruction::RIGHT => Node::create_node(side_node, path_node, parent_height),
+                Instruction::Left => Node::create_node(path_node, side_node, parent_height),
+                Instruction::Right => Node::create_node(side_node, path_node, parent_height),
             }
         } else {
             // When joining two nodes, or a node and a leaf, the joined node is
@@ -86,8 +86,8 @@ impl Node {
             let parent_height = cmp::max(path_node.height(), side_node.height()) + 1;
             let parent_depth = Node::max_height() - parent_height as usize;
             match path.get_instruction(parent_depth).unwrap() {
-                Instruction::LEFT => Node::create_node(path_node, side_node, parent_height),
-                Instruction::RIGHT => Node::create_node(side_node, path_node, parent_height),
+                Instruction::Left => Node::create_node(path_node, side_node, parent_height),
+                Instruction::Right => Node::create_node(side_node, path_node, parent_height),
             }
         }
     }


### PR DESCRIPTION
Related issues:
- Untracked

This PR introduces a small layer of abstraction on top of the `Msb` trait to provide "node-level" functionality, such as getting path instructions. These functions make use of the existing `Msb` functions, like retrieving specific bits, by wrapping them in higher level functions designed for use in Merkle trees and nodes. The `Path` trait and `Instruction` enum can now better communicate the intention of the algorithms with this higher level vocabulary.

This also introduces better type safety by using enums that describe the full range of path instructions (Left or Right) rather than 0 or not 0. Lastly, this PR removes an instance of an `expect` that may result in a panic under certain circumstances. 